### PR TITLE
[IOS-2491]Fix do not close MREC issue

### DIFF
--- a/adapters/Vungle/VungleAdapter/GADMAdapterVungleInterstitial.m
+++ b/adapters/Vungle/VungleAdapter/GADMAdapterVungleInterstitial.m
@@ -6,6 +6,8 @@
 
 @interface GADMAdapterVungleInterstitial ()<VungleDelegate>
 @property(nonatomic, weak) id<GADMAdNetworkConnector> connector;
+// To avoid multiple clean up BannerAd View
+@property(nonatomic, assign) BOOL isBannerAdViewCompleted;
 @end
 
 @implementation GADMAdapterVungleInterstitial
@@ -31,7 +33,7 @@ static BOOL _isAdPresenting;
 }
 
 - (void)dealloc {
-  [self stopBeingDelegate];
+  //[self stopBeingDelegate];
 }
 
 #pragma mark - GAD Ad Network Protocol Banner Methods (MREC)
@@ -152,6 +154,9 @@ static BOOL _isAdPresenting;
 
 - (void)stopBeingDelegate {
   if (self.adapterAdType == MREC) {
+    if (self.isBannerAdViewCompleted) return;
+    self.isBannerAdViewCompleted = YES;
+
     [[VungleRouter sharedInstance] completeBannerAdViewForPlacementID:self.desiredPlacement];
     self.connector = nil;
     [[VungleRouter sharedInstance] removeDelegate:self];

--- a/adapters/Vungle/VungleAdapter/VungleRouter.m
+++ b/adapters/Vungle/VungleAdapter/VungleRouter.m
@@ -243,13 +243,9 @@
                                             placementID:placementID
                                                   error:&bannerError];
   if (success) {
-    self.isMrecPlaying = YES;
-
     return bannerView;
   } else {
     NSLog(@"Banner loading error: %@", bannerError.localizedDescription);
-    self.isMrecPlaying = NO;
-
     return nil;
   }
 
@@ -283,6 +279,12 @@
   if (delegate) {
     [delegate willShowAd];
   }
+}
+
+- (void)vungleDidShowAdForPlacementID:(nullable NSString *)placementID {
+    if ([placementID isEqualToString:self.mrecPlacementID]) {
+        self.isMrecPlaying = YES;
+    }
 }
 
 - (void)vungleWillCloseAdWithViewInfo:(nonnull VungleViewInfo *)info


### PR DESCRIPTION
To fix the issue which MREC ad doesn't close when we  tap “Close” button on TestBannerAdViewController.

The root cause is when we create a new MREC ad view : self.isMrecPlaying of VungleRouter class is set to YES, then the old MREC ad view will be cleaned up, which will call completeBannerAdViewForPlacementID: method of  VungleRouter class. In completeBannerAdViewForPlacementID: method, the self.isMrecPlaying  is set to No, which could lead to when we close TestBannerAdViewController, cannot call [[VungleSDK sharedSDK] finishedDisplayingAd].

IOS-2491