### PR TITLE
fix the issue that a banner ad is not closing correctly after first r…

### DIFF
--- a/adapters/Vungle/VungleAdapter/VungleRouter.m
+++ b/adapters/Vungle/VungleAdapter/VungleRouter.m
@@ -272,9 +272,11 @@ const CGSize kVNGBannerShortSize = {300, 50};
                                             placementID:placementID
                                                   error:&bannerError];
   if (success) {
+    self.isBannerPlaying = YES;
     return bannerView;
   } else {
     NSLog(@"Banner loading error: %@", bannerError.localizedDescription);
+    self.isBannerPlaying = NO;
   }
 
   return nil;


### PR DESCRIPTION
This commit will fix the issue that SDK won't send `/reportAd` 
after first refresh. This is caused by not closing a "previous" 
banner ad at refresh since it didn't update `isBannerPlaying` 
flag correctly. 

IOS-2542
IOS-2545