### PR TITLE
[IOS-2582]AdMob Adapter - Add video orientation to play ad option

### DIFF
--- a/adapters/Vungle/Public/Headers/VungleAdNetworkExtras.h
+++ b/adapters/Vungle/Public/Headers/VungleAdNetworkExtras.h
@@ -37,4 +37,6 @@
 
 @property(nonatomic, copy) NSString *_Nullable playingPlacement;
 
+@property(nonatomic, copy) NSNumber *_Nullable orientations;
+
 @end

--- a/adapters/Vungle/VungleAdapter/VungleRouter.m
+++ b/adapters/Vungle/VungleAdapter/VungleRouter.m
@@ -236,6 +236,17 @@ const CGSize kVNGBannerShortSize = {300, 50};
   if (extras.flexViewAutoDismissSeconds)
     [options setObject:@(extras.flexViewAutoDismissSeconds)
                 forKey:VunglePlayAdOptionKeyFlexViewAutoDismissSeconds];
+  if (extras.orientations) {
+    int appOrientation = [extras.orientations intValue];
+    NSNumber *orientations = @(UIInterfaceOrientationMaskAll);
+    if (appOrientation == 1) {
+          orientations = @(UIInterfaceOrientationMaskLandscape);
+    } else if (appOrientation == 2) {
+          orientations = @(UIInterfaceOrientationMaskPortrait);
+    }
+    options[VunglePlayAdOptionKeyOrientations] = orientations;
+  }
+
   if (![[VungleSDK sharedSDK] playAd:viewController
                              options:options
                          placementID:delegate.desiredPlacement


### PR DESCRIPTION
AdMob iOS adapter 6.5.0 does not have option to add video orientation when configuring VungleAdNetworkExtras. We should include this setting to have parity with Android.

https://github.com/Vungle/googleads-mobile-ios-mediation/blob/6.5.x/adapters/Vungle/VungleAdapter/VungleRouter.m#L233-L238

IOS-2582