### PR TITLE
[IOS-2684]Support short banner size

### DIFF
--- a/adapters/Vungle/VungleAdapter/GADMAdapterVungleInterstitial.m
+++ b/adapters/Vungle/VungleAdapter/GADMAdapterVungleInterstitial.m
@@ -60,7 +60,8 @@
 
 - (void)getBannerWithSize:(GADAdSize)adSize {
   // An array of supported ad sizes.
-  NSArray *potentials = @[NSValueFromGADAdSize(kGADAdSizeMediumRectangle), NSValueFromGADAdSize(kGADAdSizeBanner), NSValueFromGADAdSize(kGADAdSizeLeaderboard)];
+  GADAdSize shortBannerSize = GADAdSizeFromCGSize(kVNGBannerShortSize);
+  NSArray *potentials = @[NSValueFromGADAdSize(kGADAdSizeMediumRectangle), NSValueFromGADAdSize(kGADAdSizeBanner), NSValueFromGADAdSize(kGADAdSizeLeaderboard), NSValueFromGADAdSize(shortBannerSize)];
   GADAdSize closestSize = GADClosestValidSizeForAdSizes(adSize, potentials);
   // Check if given banner size is in MREC or Banner.
   id<GADMAdNetworkConnector> strongConnector = _connector;


### PR DESCRIPTION
One tricky aspect is that not all our banner ad sizes (320x50, 300x50, 728x90) confirm to the AdMob constant banner sizes. AdMob does not have a 300x50 in its set constants.  For 300x50, we may to have convert the way Facebook has done. 
We could reference what Facebook does in their AdMob adapter code to take care of supported banner sizes:
https://github.com/googleads/googleads-mobile-ios-mediation/blob/master/adapters/Facebook/FacebookAdapter/GADFBBannerAd.m#L35

IOS-2684