### PR TITLE
[Won’t Merge][IOS-2575][IOS-2574]Implement new VungleSDKDelegate callbacks in AdMob adapter

### DIFF
--- a/adapters/Vungle/VungleAdapter/GADMAdapterVungleConstants.h
+++ b/adapters/Vungle/VungleAdapter/GADMAdapterVungleConstants.h
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-static NSString *const _Nonnull kGADMAdapterVungleVersion = @"6.5.3.0";
+static NSString *const _Nonnull kGADMAdapterVungleVersion = @"6.7.0.0";
 static NSString *const _Nonnull kGADMAdapterVungleApplicationID = @"application_id";
 static NSString *const _Nonnull kGADMAdapterVunglePlacementID = @"placementID";
 static NSString *const _Nonnull kGADMAdapterVungleErrorDomain = @"com.google.mediation.vungle";

--- a/adapters/Vungle/VungleAdapter/GADMAdapterVungleDelegate.h
+++ b/adapters/Vungle/VungleAdapter/GADMAdapterVungleDelegate.h
@@ -48,8 +48,9 @@ typedef NS_ENUM(NSUInteger, BannerRouterDelegateState) {
 - (void)adAvailable;
 - (void)adNotAvailable:(nonnull NSError *)error;
 - (void)willShowAd;
-- (void)willCloseAd:(BOOL)completedView didDownload:(BOOL)didDownload;
-- (void)didCloseAd:(BOOL)completedView didDownload:(BOOL)didDownload;
+- (void)willCloseAd;
+- (void)didCloseAd;
+- (void)trackClick;
 
 @optional
 // Check is banner ad
@@ -57,6 +58,12 @@ typedef NS_ENUM(NSUInteger, BannerRouterDelegateState) {
 
 // Get banner request object
 @property(nonatomic, nonnull) GADMAdapterVungleBannerRequest *bannerRequest;
+
+// Reward user for watching a Rewarded Video Ad successfully
+- (void)rewardUser;
+
+// App will leave current application
+- (void)willLeaveApplication;
 
 // Vungle banner ad state.
 @property(nonatomic, assign) BannerRouterDelegateState bannerState;

--- a/adapters/Vungle/VungleAdapter/GADMAdapterVungleInterstitial.m
+++ b/adapters/Vungle/VungleAdapter/GADMAdapterVungleInterstitial.m
@@ -277,11 +277,8 @@
   }
 }
 
-- (void)willCloseAd:(BOOL)completedView didDownload:(BOOL)didDownload {
+- (void)willCloseAd {
   id<GADMAdNetworkConnector> strongConnector = _connector;
-  if (didDownload) {
-    [strongConnector adapterDidGetAdClick:self];
-  }
   if ([self isBannerAd]) {
     self.bannerState = BannerRouterDelegateStateClosing;
   }
@@ -292,7 +289,7 @@
   }
 }
 
-- (void)didCloseAd:(BOOL)completedView didDownload:(BOOL)didDownload {
+- (void)didCloseAd {
   if ([self isBannerAd]) {
     self.bannerState = BannerRouterDelegateStateClosed;
   }
@@ -300,6 +297,16 @@
   if (self.adapterAdType == GADMAdapterVungleAdTypeInterstitial) {
     [_connector adapterDidDismissInterstitial:self];
   }
+}
+
+- (void)trackClick {
+  id<GADMAdNetworkConnector> strongConnector = _connector;
+  [strongConnector adapterDidGetAdClick:self];
+}
+
+- (void)willLeaveApplication {
+  id<GADMAdNetworkConnector> strongConnector = _connector;
+  [strongConnector adapterWillLeaveApplication:self];
 }
 
 @end

--- a/adapters/Vungle/VungleAdapter/GADMAdapterVungleRewardedAd.m
+++ b/adapters/Vungle/VungleAdapter/GADMAdapterVungleRewardedAd.m
@@ -153,25 +153,15 @@
   }
 }
 
-- (void)didCloseAd:(BOOL)completedView didDownload:(BOOL)didDownload {
+- (void)didCloseAd {
   id<GADMediationRewardedAdEventDelegate> strongDelegate = _delegate;
-  if (completedView) {
-    [strongDelegate didEndVideo];
-    GADAdReward *reward =
-        [[GADAdReward alloc] initWithRewardType:@"vungle"
-                                   rewardAmount:[NSDecimalNumber decimalNumberWithString:@"1"]];
-    [strongDelegate didRewardUserWithReward:reward];
-  }
-  if (didDownload) {
-    [strongDelegate reportClick];
-  }
   [strongDelegate didDismissFullScreenView];
 
   GADMAdapterVungleRewardedAd __weak *weakSelf = self;
   [[GADMAdapterVungleRouter sharedInstance] removeDelegate:weakSelf];
 }
 
-- (void)willCloseAd:(BOOL)completedView didDownload:(BOOL)didDownload {
+- (void)willCloseAd {
   _isRewardedAdPresenting = NO;
   [_delegate willDismissFullScreenView];
 }
@@ -186,6 +176,20 @@
 - (void)adNotAvailable:(nonnull NSError *)error {
   _adLoadCompletionHandler(nil, error);
   [[GADMAdapterVungleRouter sharedInstance] removeDelegate:self];
+}
+
+- (void)trackClick {
+  id<GADMediationRewardedAdEventDelegate> strongDelegate = _delegate;
+  [strongDelegate reportClick];
+}
+
+- (void)rewardUser {
+  id<GADMediationRewardedAdEventDelegate> strongDelegate = _delegate;
+  [strongDelegate didEndVideo];
+  GADAdReward *reward =
+  [[GADAdReward alloc] initWithRewardType:@"vungle"
+                             rewardAmount:[NSDecimalNumber decimalNumberWithString:@"1"]];
+  [strongDelegate didRewardUserWithReward:reward];
 }
 
 @end

--- a/adapters/Vungle/VungleAdapter/GADMAdapterVungleRouter.m
+++ b/adapters/Vungle/VungleAdapter/GADMAdapterVungleRouter.m
@@ -469,14 +469,12 @@ const CGSize kVNGBannerShortSize = {300, 50};
   }
 }
 
-- (void)vungleWillCloseAdWithViewInfo:(nonnull VungleViewInfo *)info
-                          placementID:(nonnull NSString *)placementID {
+- (void)vungleWillCloseAdForPlacementID:(nonnull NSString *)placementID {
   id<GADMAdapterVungleDelegate> delegate = [self getDelegateForPlacement:placementID withBannerRouterDelegateState:BannerRouterDelegateStatePlaying];
-  [delegate willCloseAd:[info.completedView boolValue] didDownload:[info.didDownload boolValue]];
+  [delegate willCloseAd];
 }
 
-- (void)vungleDidCloseAdWithViewInfo:(nonnull VungleViewInfo *)info
-                         placementID:(nonnull NSString *)placementID {
+- (void)vungleDidCloseAdForPlacementID:(nonnull NSString *)placementID {
   id<GADMAdapterVungleDelegate> delegate = [self getDelegateForPlacement:placementID withBannerRouterDelegateState:BannerRouterDelegateStateClosing];
 
   if ([placementID isEqualToString:_bannerPlacementID]) {
@@ -489,8 +487,29 @@ const CGSize kVNGBannerShortSize = {300, 50};
     return;
   }
 
-  [delegate didCloseAd:[info.completedView boolValue] didDownload:[info.didDownload boolValue]];
+  [delegate didCloseAd];
   [self removeDelegate:delegate];
+}
+
+- (void)vungleTrackClickForPlacementID:(nullable NSString *)placementID {
+  id<GADMAdapterVungleDelegate> delegate = [self getDelegateForPlacement:placementID
+                                           withBannerRouterDelegateState:BannerRouterDelegateStatePlaying];
+  [delegate trackClick];
+}
+
+- (void)vungleRewardUserForPlacementID:(nullable NSString *)placementID {
+  id<GADMAdapterVungleDelegate> delegate = [self getDelegateForPlacement:placementID];
+  if (delegate.adapterAdType == GADMAdapterVungleAdTypeRewarded && [delegate respondsToSelector:@selector(rewardUser)]) {
+    [delegate rewardUser];
+  }
+}
+
+- (void)vungleWillLeaveApplicationForPlacementID:(nullable NSString *)placementID {
+  id<GADMAdapterVungleDelegate> delegate = [self getDelegateForPlacement:placementID
+                                           withBannerRouterDelegateState:BannerRouterDelegateStatePlaying];
+  if ([delegate respondsToSelector:@selector(willLeaveApplication)]) {
+    [delegate willLeaveApplication];
+  }
 }
 
 - (void)vungleAdPlayabilityUpdate:(BOOL)isAdPlayable


### PR DESCRIPTION
1. Implement below delegate callbacks in AdMob adapter
- (void)vungleTrackClickForPlacementID:(nullable NSString *)placementID;
- (void)vungleRewardUserForPlacementID:(nullable NSString *)placementID;
- (void)vungleWillLeaveApplicationForPlacementID:(nullable NSString *)placementID;
2、Verify all callbacks are set properly
IOS-2574
IOS-2575


