### PR TITLE
[IOS-2811]Fix report ad is not called issue

### DIFF
--- a/adapters/Vungle/VungleAdapter/GADMAdapterVungleRouter.m
+++ b/adapters/Vungle/VungleAdapter/GADMAdapterVungleRouter.m
@@ -377,8 +377,11 @@ const CGSize kVNGBannerShortSize = {300, 50};
 }
 
 - (void)vungleDidShowAdForPlacementID:(nullable NSString *)placementID {
-  if ([placementID isEqualToString:_bannerPlacementID]) {
+  if ([placementID isEqualToString:_bannerPlacementID] || !_bannerPlacementID) {
     _isBannerPresenting = YES;
+    if (!_bannerPlacementID) {
+      _bannerPlacementID = placementID;
+    }
   }
 }
 


### PR DESCRIPTION
As Aki mentioned in ticket [IOS-2811](https://vungle.atlassian.net/browse/IOS-2811):

[GADMAdapterVungleRouter.m#L350 ](https://github.com/Vungle/googleads-mobile-ios-mediation/blob/6.5.2/adapters/Vungle/VungleAdapter/GADMAdapterVungleRouter.m#L350)
`I found that in this flow (after refresh to 2nd ad and close it), _isBannerPresenting is NO or (delegate.bannerState == BannerRouterDelegateStatePlaying) is not true, so then, [[VungleSDK sharedSDK] finishedDisplayingAd]; won’t be called.  So report_ad won’t be fired.
Even more, banner ad is not closed properly. `

After the investigation, this issue is caused by SDK calling the method `- (void)vungleDidCloseAdWithViewInfo:placementID:` for the previous Banner ad firstly when closed the previous Banner ad, in this method the `_bannerPlacementID` is set to `nil`. Then SDK displayed the new Banner ad which will call `- (void)vungleDidShowAdForPlacementID:` method for the new Banner ad, in the method `- (void)vungleDidShowAdForPlacementID:`, `_bannerPlacementID` is nil, so `_isBannerPresenting` cannot be set to `YES`. I updated the related logic to fix the issue.

IOS-2811


