### PR TITLE
[IOS-2827]Support multiple Banners with same placementID

### DIFF
--- a/adapters/Vungle/Public/Headers/VungleAdNetworkExtras.h
+++ b/adapters/Vungle/Public/Headers/VungleAdNetworkExtras.h
@@ -39,4 +39,6 @@
 
 @property(nonatomic, copy) NSNumber *_Nullable orientations;
 
+@property(nonatomic, copy, readonly) NSString *_Nonnull UUID;
+
 @end

--- a/adapters/Vungle/VungleAdapter/GADMAdapterVungleDelegate.h
+++ b/adapters/Vungle/VungleAdapter/GADMAdapterVungleDelegate.h
@@ -32,6 +32,8 @@ typedef NS_ENUM(NSUInteger, BannerRouterDelegateState) {
   BannerRouterDelegateStateClosed
 };
 
+@class GADMAdapterVungleBannerRequest;
+
 /// Delegate for receiving state change messages from the Vungle SDK.
 @protocol GADMAdapterVungleDelegate <NSObject>
 
@@ -51,6 +53,9 @@ typedef NS_ENUM(NSUInteger, BannerRouterDelegateState) {
 @optional
 // Check is banner ad
 - (BOOL)isBannerAd;
+
+// Get banner request object
+@property(nonatomic, nonnull) GADMAdapterVungleBannerRequest *bannerRequest;
 
 // Vungle banner ad state.
 @property(nonatomic, assign) BannerRouterDelegateState bannerState;

--- a/adapters/Vungle/VungleAdapter/GADMAdapterVungleInterstitial.m
+++ b/adapters/Vungle/VungleAdapter/GADMAdapterVungleInterstitial.m
@@ -179,9 +179,11 @@
 
     [[GADMAdapterVungleRouter sharedInstance]
         completeBannerAdViewForPlacementID:self];
+    [[GADMAdapterVungleRouter sharedInstance] removeBannerDelegate:self];
+  } else {
+    [[GADMAdapterVungleRouter sharedInstance] removeDelegate:self];
   }
   _connector = nil;
-  [[GADMAdapterVungleRouter sharedInstance] removeBannerDelegate:self];
 }
 
 - (BOOL)isBannerAnimationOK:(GADMBannerAnimationType)animType {

--- a/adapters/Vungle/VungleAdapter/GADMAdapterVungleInterstitial.m
+++ b/adapters/Vungle/VungleAdapter/GADMAdapterVungleInterstitial.m
@@ -88,9 +88,11 @@
     return;
   }
 
+  VungleAdNetworkExtras *networkExtras = [strongConnector networkExtras];
   self.desiredPlacement = [GADMAdapterVungleUtils findPlacement:[strongConnector credentials]
-                                                  networkExtras:[strongConnector networkExtras]];
-
+                                                  networkExtras:networkExtras];
+  self.bannerRequest = [[GADMAdapterVungleBannerRequest alloc] initWithPlacementID:self.desiredPlacement ?: @""
+                                                                uniquePubRequestID:networkExtras.UUID ?: @""];
   if (!self.desiredPlacement) {
     [strongConnector adapter:self
                    didFailAd:GADMAdapterVungleErrorWithCodeAndDescription(
@@ -101,7 +103,7 @@
   // Check if a banner or MREC ad has been initiated with the samne PlacementID
   // or not. (Vungle supports 4 types of banner currently.)
   if (![[GADMAdapterVungleRouter sharedInstance]
-          canRequestBannerAdForPlacementID:self.desiredPlacement]) {
+          canRequestBannerAdForPlacementID:self.bannerRequest]) {
     NSError *error = GADMAdapterVungleErrorWithCodeAndDescription(
         kGADErrorMediationAdapterError, @"A banner ad type has already been "
                                         @"instantiated. Multiple banner ads are not "
@@ -176,10 +178,10 @@
     _didBannerFinishPresenting = YES;
 
     [[GADMAdapterVungleRouter sharedInstance]
-        completeBannerAdViewForPlacementID:self.desiredPlacement];
+        completeBannerAdViewForPlacementID:self];
   }
   _connector = nil;
-  [[GADMAdapterVungleRouter sharedInstance] removeDelegate:self];
+  [[GADMAdapterVungleRouter sharedInstance] removeBannerDelegate:self];
 }
 
 - (BOOL)isBannerAnimationOK:(GADMBannerAnimationType)animType {
@@ -239,6 +241,7 @@
 @synthesize desiredPlacement;
 @synthesize adapterAdType;
 @synthesize bannerState;
+@synthesize bannerRequest;
 
 - (void)initialized:(BOOL)isSuccess error:(nullable NSError *)error {
   if (!isSuccess) {

--- a/adapters/Vungle/VungleAdapter/GADMAdapterVungleRouter.h
+++ b/adapters/Vungle/VungleAdapter/GADMAdapterVungleRouter.h
@@ -30,12 +30,23 @@ extern const CGSize kVNGBannerShortSize;
 - (nullable NSError *)loadAd:(nonnull NSString *)placement
                 withDelegate:(nonnull id<GADMAdapterVungleDelegate>)delegate;
 - (void)removeDelegate:(nonnull id<GADMAdapterVungleDelegate>)delegate;
+- (void)removeBannerDelegate:(nonnull id<GADMAdapterVungleDelegate>)delegate;
 - (BOOL)hasDelegateForPlacementID:(nonnull NSString *)placementID
                       adapterType:(GADMAdapterVungleAdType)adapterType;
 - (nullable UIView *)renderBannerAdInView:(nonnull UIView *)bannerView
                                  delegate:(nonnull id<GADMAdapterVungleDelegate>)delegate
                                    extras:(nullable VungleAdNetworkExtras *)extras
                            forPlacementID:(nonnull NSString *)placementID;
-- (void)completeBannerAdViewForPlacementID:(nullable NSString *)placementID;
-- (BOOL)canRequestBannerAdForPlacementID:(nonnull NSString *)placmentID;
+- (void)completeBannerAdViewForPlacementID:(nonnull id<GADMAdapterVungleDelegate>)delegate;
+- (BOOL)canRequestBannerAdForPlacementID:(nonnull GADMAdapterVungleBannerRequest *)bannerRequest;
+@end
+
+@interface GADMAdapterVungleBannerRequest : NSObject <NSCopying>
+
+- (nonnull instancetype)initWithPlacementID:(nonnull NSString *)placementID
+                         uniquePubRequestID:(nonnull NSString *)uniquePubRequestID;
+
+@property(nonatomic, copy, readonly) NSString *_Nonnull placementID;
+@property(nonatomic, copy, readonly) NSString *_Nonnull uniquePubRequestID;
+
 @end

--- a/adapters/Vungle/VungleAdapter/GADMAdapterVungleRouter.m
+++ b/adapters/Vungle/VungleAdapter/GADMAdapterVungleRouter.m
@@ -27,7 +27,7 @@ const CGSize kVNGBannerShortSize = {300, 50};
   NSMapTable<NSString *, id<GADMAdapterVungleDelegate>> *_initializingDelegates;
 
   /// Map table to hold the banner ad delegates with placement ID as a key.
-  NSMapTable<NSString *, id<GADMAdapterVungleDelegate>> *_bannerDelegates;
+  NSMapTable<GADMAdapterVungleBannerRequest *, NSMutableOrderedSet<id<GADMAdapterVungleDelegate>> *> *_bannerDelegates;
 
   /// Indicates whether a banner ad is presenting.
   BOOL _isBannerPresenting;
@@ -57,7 +57,7 @@ const CGSize kVNGBannerShortSize = {300, 50};
     _initializingDelegates = [NSMapTable mapTableWithKeyOptions:NSPointerFunctionsStrongMemory
                                                    valueOptions:NSPointerFunctionsWeakMemory];
     _bannerDelegates = [NSMapTable mapTableWithKeyOptions:NSPointerFunctionsStrongMemory
-                                             valueOptions:NSPointerFunctionsWeakMemory];
+                                             valueOptions:NSPointerFunctionsStrongMemory];
   }
   return self;
 }
@@ -117,7 +117,7 @@ const CGSize kVNGBannerShortSize = {300, 50};
   return [[VungleSDK sharedSDK] isAdCachedForPlacementID:placementID withSize:[self getVungleBannerAdSizeType:adType]];
 }
 
-- (void)addDelegate:(nonnull id<GADMAdapterVungleDelegate>)delegate {
+- (BOOL)addDelegate:(nonnull id<GADMAdapterVungleDelegate>)delegate {
   if (delegate.adapterAdType == GADMAdapterVungleAdTypeInterstitial ||
       delegate.adapterAdType == GADMAdapterVungleAdTypeRewarded) {
     @synchronized(_delegates) {
@@ -127,24 +127,48 @@ const CGSize kVNGBannerShortSize = {300, 50};
     }
   } else if ([delegate respondsToSelector:@selector(isBannerAd)] && [delegate isBannerAd]) {
     @synchronized(_bannerDelegates) {
-      _bannerPlacementID = [delegate.desiredPlacement copy];
-      if (delegate && ![_bannerDelegates objectForKey:delegate.desiredPlacement]) {
-        GADMAdapterVungleMapTableSetObjectForKey(_bannerDelegates, delegate.desiredPlacement,
-                                                 delegate);
+      if (delegate && ![_bannerDelegates objectForKey:delegate.bannerRequest]) {
+        NSEnumerator *enumerator = _bannerDelegates.keyEnumerator;
+        GADMAdapterVungleBannerRequest *bannerRequest = nil;
+        while (bannerRequest = [enumerator nextObject]) {
+          if ([bannerRequest.placementID isEqualToString:delegate.bannerRequest.placementID]) {
+            return NO;
+          }
+        }
+
+        NSMutableOrderedSet *set = [[NSMutableOrderedSet alloc] initWithObject:delegate];
+        GADMAdapterVungleMapTableSetObjectForKey(_bannerDelegates, delegate.bannerRequest,
+                                                 set);
+        _bannerPlacementID = [delegate.desiredPlacement copy];
+      } else if (delegate && [_bannerDelegates objectForKey:delegate.bannerRequest]) {
+        NSMutableOrderedSet *set = [[_bannerDelegates objectForKey:delegate.bannerRequest] mutableCopy];
+        if (![set containsObject:delegate]) {
+          GADMAdapterVungleMapTableRemoveObjectForKey(_bannerDelegates, delegate.bannerRequest);
+          [set addObject:delegate];
+          GADMAdapterVungleMapTableSetObjectForKey(_bannerDelegates, delegate.bannerRequest,
+          set);
+          _bannerPlacementID = [delegate.desiredPlacement copy];
+        }
       }
     }
   }
+  return YES;
 }
 
 - (nullable id<GADMAdapterVungleDelegate>)getDelegateForPlacement:(nonnull NSString *)placement {
   id<GADMAdapterVungleDelegate> delegate = nil;
   if ([placement isEqualToString:_bannerPlacementID]) {
     @synchronized(_bannerDelegates) {
-      if ([_bannerDelegates objectForKey:placement]) {
-        delegate = [_bannerDelegates objectForKey:placement];
-        if (delegate.bannerState != BannerRouterDelegateStateRequesting) {
-          delegate = nil;
+      NSEnumerator *enumerator = _bannerDelegates.keyEnumerator;
+      GADMAdapterVungleBannerRequest *bannerRequest = nil;
+      while (bannerRequest = [enumerator nextObject]) {
+        if ([bannerRequest.placementID isEqualToString:placement]) {
+          delegate = [[_bannerDelegates objectForKey:bannerRequest] objectAtIndex:0];
+          break;
         }
+      }
+      if (delegate != nil && delegate.bannerState != BannerRouterDelegateStateRequesting) {
+        delegate = nil;
       }
     }
   } else {
@@ -166,10 +190,22 @@ const CGSize kVNGBannerShortSize = {300, 50};
         GADMAdapterVungleMapTableRemoveObjectForKey(_delegates, delegate.desiredPlacement);
       }
     }
-  } else if ([delegate respondsToSelector:@selector(isBannerAd)] && [delegate isBannerAd]) {
+  }
+}
+
+- (void)removeBannerDelegate:(nonnull id<GADMAdapterVungleDelegate>)delegate {
+  if ([delegate respondsToSelector:@selector(isBannerAd)] && [delegate isBannerAd]) {
     @synchronized(_bannerDelegates) {
-      if (delegate && [_bannerDelegates objectForKey:delegate.desiredPlacement]) {
-        GADMAdapterVungleMapTableRemoveObjectForKey(_bannerDelegates, delegate.desiredPlacement);
+      if (delegate && [_bannerDelegates objectForKey:delegate.bannerRequest]) {
+        NSMutableOrderedSet *set = [[_bannerDelegates objectForKey:delegate.bannerRequest] mutableCopy];
+        if ([set containsObject:delegate]) {
+          GADMAdapterVungleMapTableRemoveObjectForKey(_bannerDelegates, delegate.bannerRequest);
+          [set removeObject:delegate];
+          if ([set count] > 0) {
+            GADMAdapterVungleMapTableSetObjectForKey(_bannerDelegates, delegate.bannerRequest,
+                                                     set);
+          }
+        }
       }
     }
   }
@@ -195,11 +231,13 @@ const CGSize kVNGBannerShortSize = {300, 50};
   return NO;
 }
 
-- (BOOL)canRequestBannerAdForPlacementID:(nonnull NSString *)placmentID {
-  if (_bannerDelegates.count > 0) {
-    return _bannerPlacementID == nil || [_bannerPlacementID isEqualToString:placmentID];
+- (BOOL)canRequestBannerAdForPlacementID:(nonnull GADMAdapterVungleBannerRequest *)bannerRequest {
+  @synchronized(_bannerDelegates) {
+    if (_bannerDelegates.count > 0) {
+      return _bannerPlacementID == nil || [_bannerDelegates objectForKey:bannerRequest];
     }
-  return YES;
+    return YES;
+  }
 }
 
 - (nullable NSError *)loadAd:(nonnull NSString *)placement
@@ -210,7 +248,14 @@ const CGSize kVNGBannerShortSize = {300, 50};
         kGADErrorMediationAdapterError, @"Can't request ad if another request is processing.");
     return error;
   }
-  [self addDelegate:delegate];
+  BOOL addSuccessed = [self addDelegate:delegate];
+  if (!addSuccessed) {
+    NSError *error = GADMAdapterVungleErrorWithCodeAndDescription(
+                                                                  kGADErrorMediationAdapterError, @"A banner ad type has already been "
+                                                                  @"instantiated. Multiple banner ads are not "
+                                                                  @"supported with Vungle iOS SDK.");
+    return error;
+  }
 
   VungleSDK *sdk = [VungleSDK sharedSDK];
   if ([self isAdCachedForPlacementID:placement withDelegate:delegate]) {
@@ -341,17 +386,23 @@ const CGSize kVNGBannerShortSize = {300, 50};
   return nil;
 }
 
-- (void)completeBannerAdViewForPlacementID:(nullable NSString *)placementID {
-  if (!placementID) {
-    return;
-  }
+- (void)completeBannerAdViewForPlacementID:(nonnull id<GADMAdapterVungleDelegate>)delegate; {
+  @synchronized(self) {
+    if (!delegate) {
+      return;
+    }
 
-  id<GADMAdapterVungleDelegate> delegate = [_bannerDelegates objectForKey:placementID];
-  if (_isBannerPresenting || (delegate.bannerState == BannerRouterDelegateStatePlaying)) {
-    NSLog(@"Vungle: Triggering an ad completion call for %@", placementID);
+    NSMutableOrderedSet *set = [_bannerDelegates objectForKey:delegate.bannerRequest];
+    if (!set) {
+      return;
+    }
 
-    [[VungleSDK sharedSDK] finishedDisplayingAd];
-    _isBannerPresenting = NO;
+    if (_isBannerPresenting || (delegate.bannerState == BannerRouterDelegateStatePlaying)) {
+      NSLog(@"Vungle: Triggering an ad completion call for %@", delegate.desiredPlacement);
+
+      [[VungleSDK sharedSDK] finishedDisplayingAd];
+      _isBannerPresenting = NO;
+    }
   }
 }
 
@@ -442,6 +493,67 @@ const CGSize kVNGBannerShortSize = {300, 50};
 
 - (void)vungleSDKFailedToInitializeWithError:(nonnull NSError *)error {
   [self initialized:false error:error];
+}
+
+@end
+
+@interface GADMAdapterVungleBannerRequest ()
+
+@property(nonatomic, copy) NSString *placementID;
+@property(nonatomic, copy) NSString *uniquePubRequestID;
+
+@end
+
+@implementation GADMAdapterVungleBannerRequest
+
+- (nonnull instancetype)initWithPlacementID:(nonnull NSString *)placementID
+                         uniquePubRequestID:(nonnull NSString *)uniquePubRequestID{
+  self = [super init];
+  if (self) {
+    _placementID = [placementID copy];
+    _uniquePubRequestID = [uniquePubRequestID copy];
+  }
+  return self;
+}
+
+- (nonnull instancetype)init {
+  return [self initWithPlacementID:@"" uniquePubRequestID:@""];
+}
+
+- (instancetype)copyWithZone:(NSZone *)zone {
+  GADMAdapterVungleBannerRequest *copy = [[[self class] alloc] init];
+  if (copy) {
+    copy.placementID = [self.placementID copyWithZone:zone];
+    copy.uniquePubRequestID = [self.uniquePubRequestID copyWithZone:zone];
+  }
+  return copy;
+}
+
+- (BOOL)isEqualToBannerRequest:(GADMAdapterVungleBannerRequest *)bannerRequest {
+  if (!bannerRequest) {
+    return NO;
+  }
+
+  BOOL haveEqualPlacementIDs = [self.placementID isEqualToString:bannerRequest.placementID];
+  BOOL haveEqualUniquePubRequestIDs = [self.uniquePubRequestID isEqualToString:bannerRequest.uniquePubRequestID];
+
+  return haveEqualPlacementIDs && haveEqualUniquePubRequestIDs;
+}
+
+- (BOOL)isEqual:(id)object {
+  if (self == object) {
+    return YES;
+  }
+
+  if (![object isKindOfClass:[GADMAdapterVungleBannerRequest class]]) {
+    return NO;
+  }
+
+  return [self isEqualToBannerRequest:(GADMAdapterVungleBannerRequest *)object];
+}
+
+- (NSUInteger)hash {
+  return [self.placementID hash] ^ [self.uniquePubRequestID hash];
 }
 
 @end

--- a/adapters/Vungle/VungleAdapter/GADMAdapterVungleRouter.m
+++ b/adapters/Vungle/VungleAdapter/GADMAdapterVungleRouter.m
@@ -118,6 +118,10 @@ const CGSize kVNGBannerShortSize = {300, 50};
 }
 
 - (BOOL)addDelegate:(nonnull id<GADMAdapterVungleDelegate>)delegate {
+  if (!delegate) {
+    return NO;
+  }
+
   if (delegate.adapterAdType == GADMAdapterVungleAdTypeInterstitial ||
       delegate.adapterAdType == GADMAdapterVungleAdTypeRewarded) {
     @synchronized(_delegates) {
@@ -137,16 +141,14 @@ const CGSize kVNGBannerShortSize = {300, 50};
         }
 
         NSMutableOrderedSet *set = [[NSMutableOrderedSet alloc] initWithObject:delegate];
-        GADMAdapterVungleMapTableSetObjectForKey(_bannerDelegates, delegate.bannerRequest,
-                                                 set);
+        GADMAdapterVungleMapTableSetObjectForKey(_bannerDelegates, delegate.bannerRequest, set);
         _bannerPlacementID = [delegate.desiredPlacement copy];
       } else if (delegate && [_bannerDelegates objectForKey:delegate.bannerRequest]) {
         NSMutableOrderedSet *set = [[_bannerDelegates objectForKey:delegate.bannerRequest] mutableCopy];
         if (![set containsObject:delegate]) {
           GADMAdapterVungleMapTableRemoveObjectForKey(_bannerDelegates, delegate.bannerRequest);
           [set addObject:delegate];
-          GADMAdapterVungleMapTableSetObjectForKey(_bannerDelegates, delegate.bannerRequest,
-          set);
+          GADMAdapterVungleMapTableSetObjectForKey(_bannerDelegates, delegate.bannerRequest, set);
           _bannerPlacementID = [delegate.desiredPlacement copy];
         }
       }
@@ -250,10 +252,16 @@ const CGSize kVNGBannerShortSize = {300, 50};
   }
   BOOL addSuccessed = [self addDelegate:delegate];
   if (!addSuccessed) {
-    NSError *error = GADMAdapterVungleErrorWithCodeAndDescription(
-                                                                  kGADErrorMediationAdapterError, @"A banner ad type has already been "
-                                                                  @"instantiated. Multiple banner ads are not "
-                                                                  @"supported with Vungle iOS SDK.");
+    NSError *error = nil;
+    if (delegate) {
+      error = GADMAdapterVungleErrorWithCodeAndDescription(
+                                                           kGADErrorMediationAdapterError, @"A banner ad type has already been "
+                                                           @"instantiated. Multiple banner ads are not "
+                                                           @"supported with Vungle iOS SDK.");
+    } else {
+      error = GADMAdapterVungleErrorWithCodeAndDescription(
+                                                           kGADErrorMediationAdapterError, @"Can't load ad when try to add a nil delegate.");
+    }
     return error;
   }
 

--- a/adapters/Vungle/VungleAdapter/VungleAdNetworkExtras.m
+++ b/adapters/Vungle/VungleAdapter/VungleAdNetworkExtras.m
@@ -16,4 +16,12 @@
 
 @implementation VungleAdNetworkExtras
 
+- (nonnull instancetype)init {
+    self = [super init];
+    if (self) {
+        _UUID = [[NSUUID UUID] UUIDString];
+    }
+    return self;
+}
+
 @end


### PR DESCRIPTION
https://vungle.atlassian.net/browse/IOS-2827
AdMob supports multiple Banners with same placementID, which Vungle doesn't support.
This change handles that limitation at adapter level, as AdMob allows multiple requests for same placement to be created simultaneously.

“UUID” needs to be added in VungleAdNetworkExtras class to be able to differentiate the adRequest for “refresh” case from one for secondary banner, with the same UnitID (= Placement ID).
AdMob told us VungleAdNetworkExtras should hold the same “values” (instance might be re-created) for refresh case, we can use this behavior to fix this issue.

IOS-2827