### PR TITLE
Fix Interstitial Ad callback issue

### DIFF
--- a/adapters/Vungle/VungleAdapter/GADMAdapterVungleRouter.m
+++ b/adapters/Vungle/VungleAdapter/GADMAdapterVungleRouter.m
@@ -380,7 +380,11 @@ const CGSize kVNGBannerShortSize = {300, 50};
   if ([placementID isEqualToString:_bannerPlacementID] || !_bannerPlacementID) {
     _isBannerPresenting = YES;
     if (!_bannerPlacementID) {
-      _bannerPlacementID = placementID;
+      id<GADMAdapterVungleDelegate> delegate = [self getDelegateForPlacement:placementID];
+      // The delegate is not Interstitial or Rewarded Video Ad
+      if (!delegate) {
+        _bannerPlacementID = placementID;
+      }
     }
   }
 }


### PR DESCRIPTION
During the test of AdMob Adapter, I found  the callbacks `-(void)willCloseAd:didDownload:` and   `-(void)didCloseAd:didDownload:` of Interstitial Ad cannot be called, this PR is the fix of this issue.