### PR TITLE
[IOS-2839][IOS-2838]Multiple Banners with same placementId improvement

### DIFF
--- a/adapters/Vungle/Public/Headers/VungleAdNetworkExtras.h
+++ b/adapters/Vungle/Public/Headers/VungleAdNetworkExtras.h
@@ -39,6 +39,6 @@
 
 @property(nonatomic, copy) NSNumber *_Nullable orientations;
 
-@property(nonatomic, copy, readonly) NSString *_Nonnull UUID;
+@property(nonatomic, copy) NSString *_Nonnull UUID;
 
 @end

--- a/adapters/Vungle/VungleAdapter/GADMAdapterVungleDelegate.h
+++ b/adapters/Vungle/VungleAdapter/GADMAdapterVungleDelegate.h
@@ -27,6 +27,7 @@ typedef NS_ENUM(NSUInteger, GADMAdapterVungleAdType) {
 typedef NS_ENUM(NSUInteger, BannerRouterDelegateState) {
   BannerRouterDelegateStateRequesting,
   BannerRouterDelegateStateCached,
+  BannerRouterDelegateStateWillPlaying,
   BannerRouterDelegateStatePlaying,
   BannerRouterDelegateStateClosing,
   BannerRouterDelegateStateClosed

--- a/adapters/Vungle/VungleAdapter/GADMAdapterVungleDelegate.h
+++ b/adapters/Vungle/VungleAdapter/GADMAdapterVungleDelegate.h
@@ -27,7 +27,7 @@ typedef NS_ENUM(NSUInteger, GADMAdapterVungleAdType) {
 typedef NS_ENUM(NSUInteger, BannerRouterDelegateState) {
   BannerRouterDelegateStateRequesting,
   BannerRouterDelegateStateCached,
-  BannerRouterDelegateStateWillPlaying,
+  BannerRouterDelegateStateWillPlay,
   BannerRouterDelegateStatePlaying,
   BannerRouterDelegateStateClosing,
   BannerRouterDelegateStateClosed

--- a/adapters/Vungle/VungleAdapter/GADMAdapterVungleInterstitial.m
+++ b/adapters/Vungle/VungleAdapter/GADMAdapterVungleInterstitial.m
@@ -225,7 +225,7 @@
     return;
   }
 
-  self.bannerState = BannerRouterDelegateStateWillPlaying;
+  self.bannerState = BannerRouterDelegateStateWillPlay;
   [_connector adapter:self didReceiveAdView:bannerView];
 }
 

--- a/adapters/Vungle/VungleAdapter/GADMAdapterVungleInterstitial.m
+++ b/adapters/Vungle/VungleAdapter/GADMAdapterVungleInterstitial.m
@@ -179,11 +179,9 @@
 
     [[GADMAdapterVungleRouter sharedInstance]
         completeBannerAdViewForPlacementID:self];
-    [[GADMAdapterVungleRouter sharedInstance] removeBannerDelegate:self];
-  } else {
-    [[GADMAdapterVungleRouter sharedInstance] removeDelegate:self];
   }
   _connector = nil;
+  [[GADMAdapterVungleRouter sharedInstance] removeDelegate:self];
 }
 
 - (BOOL)isBannerAnimationOK:(GADMBannerAnimationType)animType {
@@ -227,7 +225,7 @@
     return;
   }
 
-  self.bannerState = BannerRouterDelegateStatePlaying;
+  self.bannerState = BannerRouterDelegateStateWillPlaying;
   [_connector adapter:self didReceiveAdView:bannerView];
 }
 

--- a/adapters/Vungle/VungleAdapter/GADMAdapterVungleRouter.h
+++ b/adapters/Vungle/VungleAdapter/GADMAdapterVungleRouter.h
@@ -30,7 +30,6 @@ extern const CGSize kVNGBannerShortSize;
 - (nullable NSError *)loadAd:(nonnull NSString *)placement
                 withDelegate:(nonnull id<GADMAdapterVungleDelegate>)delegate;
 - (void)removeDelegate:(nonnull id<GADMAdapterVungleDelegate>)delegate;
-- (void)removeBannerDelegate:(nonnull id<GADMAdapterVungleDelegate>)delegate;
 - (BOOL)hasDelegateForPlacementID:(nonnull NSString *)placementID
                       adapterType:(GADMAdapterVungleAdType)adapterType;
 - (nullable UIView *)renderBannerAdInView:(nonnull UIView *)bannerView

--- a/adapters/Vungle/VungleAdapter/GADMAdapterVungleRouter.m
+++ b/adapters/Vungle/VungleAdapter/GADMAdapterVungleRouter.m
@@ -145,7 +145,7 @@ const CGSize kVNGBannerShortSize = {300, 50};
           } else {
             NSOrderedSet *set = [_bannerDelegates objectForKey:bannerRequest];
             for(id<GADMAdapterVungleDelegate> delegate in set) {
-              if (delegate.bannerState == BannerRouterDelegateStateWillPlaying || delegate.bannerState == BannerRouterDelegateStatePlaying) {
+              if (delegate.bannerState == BannerRouterDelegateStateWillPlay || delegate.bannerState == BannerRouterDelegateStatePlaying) {
                 return NO;
               }
             }
@@ -418,7 +418,7 @@ const CGSize kVNGBannerShortSize = {300, 50};
       return;
     }
 
-    if ((_isBannerPresenting && delegate.bannerState == BannerRouterDelegateStatePlaying) || delegate.bannerState == BannerRouterDelegateStateWillPlaying) {
+    if ((_isBannerPresenting && delegate.bannerState == BannerRouterDelegateStatePlaying) || delegate.bannerState == BannerRouterDelegateStateWillPlay) {
       NSLog(@"Vungle: Triggering an ad completion call for %@", delegate.desiredPlacement);
 
       [[VungleSDK sharedSDK] finishedDisplayingAd];
@@ -445,11 +445,11 @@ const CGSize kVNGBannerShortSize = {300, 50};
     return;
   }
 
-  id<GADMAdapterVungleDelegate> delegate = [self getDelegateForPlacement:placementID withBannerRouterDelegateState:BannerRouterDelegateStateWillPlaying];
+  id<GADMAdapterVungleDelegate> delegate = [self getDelegateForPlacement:placementID withBannerRouterDelegateState:BannerRouterDelegateStateWillPlay];
   // The delegate is not Interstitial or Rewarded Video Ad
   if (!delegate && ! _bannerPlacementID) {
     _bannerPlacementID = placementID;
-    delegate = [self getDelegateForPlacement:placementID withBannerRouterDelegateState:BannerRouterDelegateStateWillPlaying];
+    delegate = [self getDelegateForPlacement:placementID withBannerRouterDelegateState:BannerRouterDelegateStateWillPlay];
   }
 
   [delegate willShowAd];

--- a/adapters/Vungle/VungleAdapter/GADMAdapterVungleRouter.m
+++ b/adapters/Vungle/VungleAdapter/GADMAdapterVungleRouter.m
@@ -131,12 +131,24 @@ const CGSize kVNGBannerShortSize = {300, 50};
     }
   } else if ([delegate respondsToSelector:@selector(isBannerAd)] && [delegate isBannerAd]) {
     @synchronized(_bannerDelegates) {
+      // We only support displaying one Vungle Banner Ad at the same time currently
+      if (_bannerPlacementID != nil && ![_bannerPlacementID isEqualToString:delegate.desiredPlacement]) {
+        return NO;
+      }
+
       if (delegate && ![_bannerDelegates objectForKey:delegate.bannerRequest]) {
         NSEnumerator *enumerator = _bannerDelegates.keyEnumerator;
         GADMAdapterVungleBannerRequest *bannerRequest = nil;
         while (bannerRequest = [enumerator nextObject]) {
           if ([bannerRequest.placementID isEqualToString:delegate.bannerRequest.placementID]) {
             return NO;
+          } else {
+            NSOrderedSet *set = [_bannerDelegates objectForKey:bannerRequest];
+            for(id<GADMAdapterVungleDelegate>delegate in set) {
+              if (delegate.bannerState == BannerRouterDelegateStatePlaying) {
+                return NO;
+              }
+            }
           }
         }
 


### PR DESCRIPTION
This PR includes below three improvements:
1) When play multiple Banners with different placementIds, we need to add some judgments and protections to make sure only one Vungle Banner is displaying at the same time in multi threads environment.

2) AdMob SDK always releases the Banner delegate early, which could lead to some callbacks of  Banner cannot be received. So I update the logic to manage Banner delegate lifecycle, after calling the delegate method `vungleDidCloseAdWithViewInfo:placementID:`, then adapter could release the Banner delegate.

3) On Android side, the AdMob Adapter allowed the users to set UUID of `NetworkExtras` class. On iOS side, the UUID is `readonly` and cannot be set by users. The value of UUID is created and assigned to random value in the `init` method. We should do the same way that Android side implementation.

IOS-2839
IOS-2838