### PR TITLE
[IOS-2833]Fix ad availability delays issue

### DIFF
--- a/adapters/Vungle/VungleAdapter/GADMAdapterVungleRouter.m
+++ b/adapters/Vungle/VungleAdapter/GADMAdapterVungleRouter.m
@@ -500,15 +500,17 @@ const CGSize kVNGBannerShortSize = {300, 50};
   if (!delegate) {
     return;
   }
-  if (error) {
-    NSLog(@"Vungle Ad Playability returned an error: %@", error.localizedDescription);
-    [delegate adNotAvailable:error];
-    [self removeDelegate:delegate];
-    return;
-  }
 
   if (isAdPlayable) {
     [delegate adAvailable];
+  } else {
+    if (error) {
+      NSLog(@"Vungle Ad Playability returned an error: %@", error.localizedDescription);
+    } else {
+      error = GADMAdapterVungleErrorWithCodeAndDescription(kGADErrorMediationAdapterError, [NSString stringWithFormat:@"Ad is not available for placementID: %@.", placementID]);
+    }
+    [delegate adNotAvailable:error];
+    [self removeDelegate:delegate];
   }
 }
 


### PR DESCRIPTION
When I investigated the issue in ticket IOS-2833(https://vungle.atlassian.net/browse/IOS-2833), I found that in `-(void)vungleAdPlayabilityUpdate:placementID:error:` callback method, if the parameter `error` is nil and `isAdPlayable` is NO passed to this method, this will not call `[delegate adNotAvailable:error];` method to notify the Interstitial delegate the ad is not filled. This could lead to the AdMob SDK calls the Interstitial delegate’s clean up method until time out, which will take longer time.  Then AdMob SDK could request next priority placementID ad. So the low priority placementID will have a longer latency of ad availability . 

IOS-2833