### PR TITLE
[IOS-2885]Implement AdMob suggestion

### DIFF
--- a/adapters/Vungle/VungleAdapter/GADMAdapterVungleBannerRequest.h
+++ b/adapters/Vungle/VungleAdapter/GADMAdapterVungleBannerRequest.h
@@ -19,6 +19,8 @@
 - (nonnull instancetype)initWithPlacementID:(nonnull NSString *)placementID
                          uniquePubRequestID:(nonnull NSString *)uniquePubRequestID;
 
+- (BOOL)isEqualToBannerRequest:(nonnull GADMAdapterVungleBannerRequest *)bannerRequest;
+
 @property(nonatomic, copy, readonly) NSString *_Nonnull placementID;
 @property(nonatomic, copy, readonly) NSString *_Nonnull uniquePubRequestID;
 

--- a/adapters/Vungle/VungleAdapter/GADMAdapterVungleDelegate.h
+++ b/adapters/Vungle/VungleAdapter/GADMAdapterVungleDelegate.h
@@ -64,4 +64,7 @@ typedef NS_ENUM(NSUInteger, BannerRouterDelegateState) {
 // Is a refreshed Banner request
 @property(nonatomic, assign) BOOL isRefreshedForBannerAd;
 
+// Is request a Banner ad for a refresh request
+@property(nonatomic, assign) BOOL isRequestingBannerAdForRefresh;
+
 @end

--- a/adapters/Vungle/VungleAdapter/GADMAdapterVungleDelegate.h
+++ b/adapters/Vungle/VungleAdapter/GADMAdapterVungleDelegate.h
@@ -61,4 +61,7 @@ typedef NS_ENUM(NSUInteger, BannerRouterDelegateState) {
 // Vungle banner ad state.
 @property(nonatomic, assign) BannerRouterDelegateState bannerState;
 
+// Is a refreshed Banner request
+@property(nonatomic, assign) BOOL isRefreshedForBannerAd;
+
 @end

--- a/adapters/Vungle/VungleAdapter/GADMAdapterVungleDelegate.h
+++ b/adapters/Vungle/VungleAdapter/GADMAdapterVungleDelegate.h
@@ -64,7 +64,7 @@ typedef NS_ENUM(NSUInteger, BannerRouterDelegateState) {
 // Is a refreshed Banner request
 @property(nonatomic, assign) BOOL isRefreshedForBannerAd;
 
-// Is request a Banner ad for a refresh request
+// Is requesting a Banner ad for a refresh request
 @property(nonatomic, assign) BOOL isRequestingBannerAdForRefresh;
 
 @end

--- a/adapters/Vungle/VungleAdapter/GADMAdapterVungleInterstitial.m
+++ b/adapters/Vungle/VungleAdapter/GADMAdapterVungleInterstitial.m
@@ -40,6 +40,10 @@
   return [VungleAdNetworkExtras class];
 }
 
++ (NSString *)adapterVersion {
+  return kGADMAdapterVungleVersion;
+}
+
 - (instancetype)initWithGADMAdNetworkConnector:(id<GADMAdNetworkConnector>)connector {
   self = [super init];
   if (self) {
@@ -241,6 +245,7 @@
 @synthesize adapterAdType;
 @synthesize bannerState;
 @synthesize bannerRequest;
+@synthesize isRefreshedForBannerAd;
 
 - (void)initialized:(BOOL)isSuccess error:(nullable NSError *)error {
   if (!isSuccess) {

--- a/adapters/Vungle/VungleAdapter/GADMAdapterVungleInterstitial.m
+++ b/adapters/Vungle/VungleAdapter/GADMAdapterVungleInterstitial.m
@@ -246,6 +246,7 @@
 @synthesize bannerState;
 @synthesize bannerRequest;
 @synthesize isRefreshedForBannerAd;
+@synthesize isRequestingBannerAdForRefresh;
 
 - (void)initialized:(BOOL)isSuccess error:(nullable NSError *)error {
   if (!isSuccess) {

--- a/adapters/Vungle/VungleAdapter/GADMAdapterVungleRouter.m
+++ b/adapters/Vungle/VungleAdapter/GADMAdapterVungleRouter.m
@@ -139,16 +139,16 @@ const CGSize kVNGBannerShortSize = {300, 50};
 
       if (![_bannerDelegates objectForKey:delegate.bannerRequest]) {
         NSEnumerator *enumerator = _bannerDelegates.keyEnumerator;
-        GADMAdapterVungleBannerRequest *bannerRequest = nil;
-        while (bannerRequest = [enumerator nextObject]) {
+        GADMAdapterVungleBannerRequest *vungleBannerRequest = nil;
+        while (vungleBannerRequest = [enumerator nextObject]) {
           // There is already a banner delegate with same placementID
           // but different uniquePubRequestID in _bannerDelegates.
-          if ([bannerRequest.placementID isEqualToString:delegate.bannerRequest.placementID]) {
+          if ([vungleBannerRequest.placementID isEqualToString:delegate.bannerRequest.placementID]) {
             return NO;
-          } else if (bannerRequest.placementID && ![bannerRequest.placementID isEqualToString:delegate.bannerRequest.placementID]) {
+          } else if (vungleBannerRequest.placementID.length > 0 && ![vungleBannerRequest.placementID isEqualToString:delegate.bannerRequest.placementID]) {
             // There is already a banner delegate with different placementID in _bannerDelegates.
             if (!_bannerRequest) {
-              _bannerRequest = [bannerRequest copy];
+              _bannerRequest = [vungleBannerRequest copy];
             }
             return NO;
           }
@@ -201,10 +201,10 @@ const CGSize kVNGBannerShortSize = {300, 50};
   if ([placement isEqualToString:_bannerRequest.placementID]) {
     @synchronized(_bannerDelegates) {
       NSEnumerator *enumerator = _bannerDelegates.keyEnumerator;
-      GADMAdapterVungleBannerRequest *bannerRequest = nil;
-      while (bannerRequest = [enumerator nextObject]) {
-        if ([bannerRequest.placementID isEqualToString:placement]) {
-          id<GADMAdapterVungleDelegate> bannerDelegate = [_bannerDelegates objectForKey:bannerRequest];
+      GADMAdapterVungleBannerRequest *vungleBannerRequest = nil;
+      while (vungleBannerRequest = [enumerator nextObject]) {
+        if ([vungleBannerRequest.placementID isEqualToString:placement]) {
+          id<GADMAdapterVungleDelegate> bannerDelegate = [_bannerDelegates objectForKey:vungleBannerRequest];
           if (bannerDelegate.bannerState == bannerState) {
             return bannerDelegate;
           }

--- a/adapters/Vungle/VungleAdapter/GADMAdapterVungleRouter.m
+++ b/adapters/Vungle/VungleAdapter/GADMAdapterVungleRouter.m
@@ -159,10 +159,10 @@ const CGSize kVNGBannerShortSize = {300, 50};
       } else {
         id<GADMAdapterVungleDelegate> bannerDelegate = [_bannerDelegates objectForKey:delegate.bannerRequest];
 
-        /* This flag is used for an edge case, when the old Banner delegate is removed from
-         * _bannerDelegates and there is a refresh Banner delegate doesn't construct Banner view
-         * successfully and add to _bannerDelegates yet. Adapter cannot set _bannerRequest to nil
-         * to prevent requesting another Banner ad with different bannerRequest.
+        /* The isRequestingBannerAdForRefresh flag is used for an edge case, when the old Banner
+         * delegate is removed from _bannerDelegates and there is a refresh Banner delegate doesn't
+         * construct Banner view successfully and add to _bannerDelegates yet. Adapter cannot set
+         * _bannerRequest to nil to prevent requesting another Banner ad with different bannerRequest.
          */
         bannerDelegate.isRequestingBannerAdForRefresh = YES;
         delegate.isRefreshedForBannerAd = YES;


### PR DESCRIPTION
For AdMob latest comments in Vungle 6.5.3.0 official PR (https://github.com/googleads/googleads-mobile-ios-mediation/pull/197#discussion_r398273717),  AdMob suggested us should change the `_bannerDelegates` back to use `NSMapTable<GADMAdapterVungleBannerRequest *, id<GADMAdapterVungleDelegate>>`. 
AdMob said we don't need to track the old banner delegate lifecycle after AdMob SDK removes it (AdMob mentioned "If Google SDK is dropping the instance, it means we also dropped the ad that the adapter is responding to. So the callback likely isn't doing anything anyway (or if it's making it back, it's only because the adapter didn't let things get cleaned up)"). 

I have checked the `- (void)willCloseAd:didDownload:` and  ` - (void)didCloseAd:didDownload:` delegate methods don‘t do anything important work for Banner delegate, so if the old banner delegate is released early by AdMob SDK , we will not track these delegate methods for old banner delegate.  

We will change the `_bannerDelegates` back to use `NSMapTable<GADMAdapterVungleBannerRequest *, id<GADMAdapterVungleDelegate>>`. 

IOS-2885