### PR TITLE
[IOS-2910]Implement AdMob suggestion of refresh checking

### DIFF
--- a/adapters/Vungle/VungleAdapter/GADMAdapterVungleBannerRequest.h
+++ b/adapters/Vungle/VungleAdapter/GADMAdapterVungleBannerRequest.h
@@ -17,11 +17,11 @@
 @interface GADMAdapterVungleBannerRequest : NSObject <NSCopying>
 
 - (nonnull instancetype)initWithPlacementID:(nonnull NSString *)placementID
-                         uniquePubRequestID:(nonnull NSString *)uniquePubRequestID;
+                         uniquePubRequestID:(nullable NSString *)uniquePubRequestID;
 
 - (BOOL)isEqualToBannerRequest:(nonnull GADMAdapterVungleBannerRequest *)bannerRequest;
 
 @property(nonatomic, copy, readonly) NSString *_Nonnull placementID;
-@property(nonatomic, copy, readonly) NSString *_Nonnull uniquePubRequestID;
+@property(nonatomic, copy, readonly) NSString *_Nullable uniquePubRequestID;
 
 @end

--- a/adapters/Vungle/VungleAdapter/GADMAdapterVungleBannerRequest.m
+++ b/adapters/Vungle/VungleAdapter/GADMAdapterVungleBannerRequest.m
@@ -24,7 +24,7 @@
 @implementation GADMAdapterVungleBannerRequest
 
 - (nonnull instancetype)initWithPlacementID:(nonnull NSString *)placementID
-                         uniquePubRequestID:(nonnull NSString *)uniquePubRequestID{
+                         uniquePubRequestID:(nullable NSString *)uniquePubRequestID {
   self = [super init];
   if (self) {
     _placementID = [placementID copy];
@@ -34,7 +34,7 @@
 }
 
 - (nonnull instancetype)init {
-  return [self initWithPlacementID:@"" uniquePubRequestID:@""];
+  return [self initWithPlacementID:@"" uniquePubRequestID:nil];
 }
 
 - (instancetype)copyWithZone:(NSZone *)zone {

--- a/adapters/Vungle/VungleAdapter/GADMAdapterVungleInterstitial.m
+++ b/adapters/Vungle/VungleAdapter/GADMAdapterVungleInterstitial.m
@@ -97,7 +97,7 @@
   self.desiredPlacement = [GADMAdapterVungleUtils findPlacement:[strongConnector credentials]
                                                   networkExtras:networkExtras];
   self.bannerRequest = [[GADMAdapterVungleBannerRequest alloc] initWithPlacementID:self.desiredPlacement ?: @""
-                                                                uniquePubRequestID:networkExtras.UUID ?: @""];
+                                                                uniquePubRequestID:networkExtras.UUID];
   if (!self.desiredPlacement) {
     [strongConnector adapter:self
                    didFailAd:GADMAdapterVungleErrorWithCodeAndDescription(


### PR DESCRIPTION
AdMob made a new comment after they tested our 6.5.3 Adapter (https://github.com/googleads/googleads-mobile-ios-mediation/pull/197#discussion_r403400924).

AdMob has asked us to assume if we get Banner AdRequest with no unique ID in case Pub did not implement our integration suggestion to register `VungleAdNetworkExtras`,  so uniqueID is nil. For the next Banner ad request with same placementID, adapter cannot determine if it for the refresh or for another new Banner ad request, the adapter will refuse to load next Banner ad request with same placementID.

Android side already implemented this suggestion. This suggestion will have some side effect on reducing chances for Vungle to fill for Banner refresh, if current request is already filled by Vungle and Banner is already been shown, but pubs don't register networkExtras(so uniqueID is nil). Vungle however could not participate in next to the following AdRequest as by then the Vungle Banner would have been closed and no active Banner ads being shows for that Placement.  So the refresh Banner request fails to load.

IOS-2910