### PR TITLE
[IOS-2992]Set CCPA status at adapter level

### DIFF
--- a/adapters/Vungle/Public/Headers/VungleRouterConfiguration.h
+++ b/adapters/Vungle/Public/Headers/VungleRouterConfiguration.h
@@ -16,8 +16,12 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+typedef NS_ENUM(NSInteger, VungleCCPAStatus);
+
 @interface VungleRouterConfiguration : NSObject
 + (void)setPublishIDFV:(BOOL)publish;
++ (void)setCCPAStatus:(VungleCCPAStatus)ccpaStatus;
++ (VungleCCPAStatus)getCCPAStatus;
 + (void)setMinSpaceForInit:(int)size;
 + (void)setMinSpaceForAdLoad:(int)size;
 @end

--- a/adapters/Vungle/VungleAdapter/VungleRouterConfiguration.m
+++ b/adapters/Vungle/VungleAdapter/VungleRouterConfiguration.m
@@ -22,6 +22,14 @@ static NSString *const kAdapterMinimumFileSystemSizeForAssetDownload =
   [VungleSDK setPublishIDFV:publish];
 }
 
++ (void)setCCPAStatus:(VungleCCPAStatus)ccpaStatus {
+  [[VungleSDK sharedSDK] updateCCPAStatus:ccpaStatus];
+}
+
++ (VungleCCPAStatus)getCCPAStatus {
+  return [[VungleSDK sharedSDK] getCurrentCCPAStatus];
+}
+
 + (void)setMinSpaceForInit:(int)size {
   if (size >= 0) {
     [[NSUserDefaults standardUserDefaults] setInteger:size


### PR DESCRIPTION
Regarding CCPA, there are concerns raised by IE team about setting CCPA via SDK instead via adapters. 
For AdMob Adapter, we need to open api through public header `VungleRouterConfiguration` or else, I think the public head `VungleRouterConfiguration` is suitable to set CCPA status.

IOS-2992