### PR TITLE
[IOS-3245]Remove ResetPlacementForDifferentAdSize error check

### DIFF
--- a/adapters/Vungle/CHANGELOG.md
+++ b/adapters/Vungle/CHANGELOG.md
@@ -3,6 +3,7 @@
 #### Version 6.8.0.0
 - Verified compatibility with Vungle SDK 6.8.0.
 - Now requires Google Mobile Ads SDK version 7.65.0 or higher.
+- Remove VungleSDKResetPlacementForDifferentAdSize error check for loading Ads.
 
 Build and tested with
 - Google Mobile Ads SDK version 7.65.0.

--- a/adapters/Vungle/VungleAdapter/GADMAdapterVungleRouter.m
+++ b/adapters/Vungle/VungleAdapter/GADMAdapterVungleRouter.m
@@ -320,12 +320,6 @@ static NSString *const _Nonnull kGADMAdapterVungleNullPubRequestID = @"null";
     [sdk loadPlacementWithID:placement error:&loadError];
   }
 
-  // For the VungleSDKResetPlacementForDifferentAdSize error, Vungle SDK currently still tries to
-  // cache an ad for the new size. Adapter treats this as not an error for now.
-  // TODO: Remove this error override once Vungle SDK is updated to stop returning this error.
-  if (loadError.code == VungleSDKResetPlacementForDifferentAdSize) {
-    loadError = nil;
-  }
   return loadError;
 }
 


### PR DESCRIPTION
Currently when Banner ad is requested with different ad size from the size of `cached ad`, `loadPlacementWithID` in `VunglePlacementsCoordinator` will return `Yes` and not return `NO` or `error` any more in our native SDK. So we could remove the `VungleSDKResetPlacementForDifferentAdSize` error code check when requesting a different Banner ad size from the size of `cached Banner ad`.

IOS-3245