### PR TITLE
[IOS-3432]Implement new SDK callback `vungleAdViewedForPlacement:` in AdMob adapter 

### DIFF
--- a/adapters/Vungle/VungleAdapter/GADMAdapterVungleBanner.m
+++ b/adapters/Vungle/VungleAdapter/GADMAdapterVungleBanner.m
@@ -194,6 +194,10 @@
   self.bannerState = BannerRouterDelegateStatePlaying;
 }
 
+- (void)didViewAd {
+  // Do nothing.
+}
+
 - (void)willCloseAd {
   self.bannerState = BannerRouterDelegateStateClosing;
   // This callback is fired when the banner itself is destroyed/removed, not when the user returns

--- a/adapters/Vungle/VungleAdapter/GADMAdapterVungleDelegate.h
+++ b/adapters/Vungle/VungleAdapter/GADMAdapterVungleDelegate.h
@@ -33,6 +33,7 @@ typedef NS_ENUM(NSUInteger, BannerRouterDelegateState) {
 - (void)adAvailable;
 - (void)adNotAvailable:(nonnull NSError *)error;
 - (void)willShowAd;
+- (void)didViewAd;
 - (void)willCloseAd;
 - (void)didCloseAd;
 - (void)trackClick;

--- a/adapters/Vungle/VungleAdapter/GADMAdapterVungleInterstitial.m
+++ b/adapters/Vungle/VungleAdapter/GADMAdapterVungleInterstitial.m
@@ -168,6 +168,10 @@
 }
 
 - (void)willShowAd {
+  // Do nothing.
+}
+
+- (void)didViewAd {
   [_connector adapterWillPresentInterstitial:self];
 }
 

--- a/adapters/Vungle/VungleAdapter/GADMAdapterVungleRewardedAd.m
+++ b/adapters/Vungle/VungleAdapter/GADMAdapterVungleRewardedAd.m
@@ -166,8 +166,11 @@
 - (void)willShowAd {
   id<GADMediationRewardedAdEventDelegate> strongDelegate = _delegate;
   [strongDelegate willPresentFullScreenView];
-  [strongDelegate reportImpression];
   [strongDelegate didStartVideo];
+}
+
+- (void)didViewAd {
+  [_delegate reportImpression];
 }
 
 - (void)adNotAvailable:(nonnull NSError *)error {

--- a/adapters/Vungle/VungleAdapter/GADMAdapterVungleRouter.m
+++ b/adapters/Vungle/VungleAdapter/GADMAdapterVungleRouter.m
@@ -452,6 +452,13 @@ static NSString *const _Nonnull kGADMAdapterVungleNullPubRequestID = @"null";
   NSLog(@"Vungle: Did show Ad for placement ID:%@", placementID);
 }
 
+- (void)vungleAdViewedForPlacement:(NSString *)placementID {
+  id<GADMAdapterVungleDelegate> delegate =
+      [self getDelegateForPlacement:placementID
+          withBannerRouterDelegateState:BannerRouterDelegateStatePlaying];
+  [delegate didViewAd];
+}
+
 - (void)vungleWillCloseAdForPlacementID:(nonnull NSString *)placementID {
   id<GADMAdapterVungleDelegate> delegate =
       [self getDelegateForPlacement:placementID


### PR DESCRIPTION
This PR is implementing the new SDK callback `vungleAdViewedForPlacement:` in AdMob adapter. Base on the synchronization result of Aki, Clarke with AdMob side:

Interstitial：  Vungle: - (void)vungleAdViewedForPlacement: -> AdMob: adapterWillPresentInterstitial
Rewarded Ad：   Vungle: - (void)vungleAdViewedForPlacement: -> AdMob: reportImpression

IOS-3432