### PR TITLE
[IOS-4190] Native Ad Implementation

### DIFF
--- a/adapters/AppLovin/AppLovinAdapter/GADMAdapterAppLovinConstant.m
+++ b/adapters/AppLovin/AppLovinAdapter/GADMAdapterAppLovinConstant.m
@@ -14,7 +14,7 @@ NSString *const GADMAdapterAppLovinSDKErrorDomain = @"com.google.mediation.applo
 
 NSString *const GADMAdapterAppLovinInfoPListSDKKey = @"AppLovinSdkKey";
 
-NSString *const GADMAdapterAppLovinAdapterVersion = @"10.3.6.0";
+NSString *const GADMAdapterAppLovinAdapterVersion = @"10.3.7.0";
 
 NSString *const GADMAdapterAppLovinSDKKey = @"sdkKey";
 

--- a/adapters/AppLovin/CHANGELOG.md
+++ b/adapters/AppLovin/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## AppLovin iOS Mediation Adapter Changelog
 
+#### Version 10.3.7.0 (In progress)
+- Verified compatibility with AppLovin SDK 10.3.7.
+
+Built and tested with:
+- Google Mobile Ads SDK version 8.12.0.
+- AppLovin SDK version 10.3.7.
+
 #### [Version 10.3.6.0](https://dl.google.com/googleadmobadssdk/mediation/ios/applovin/AppLovinAdapter-10.3.6.0.zip)
 - Verified compatibility with AppLovin SDK 10.3.6.
 - Now requires minimum iOS version 10.0.

--- a/adapters/AppLovin/CHANGELOG.md
+++ b/adapters/AppLovin/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## AppLovin iOS Mediation Adapter Changelog
 
-#### Version 10.3.7.0 (In progress)
+#### [Version 10.3.7.0](https://dl.google.com/googleadmobadssdk/mediation/ios/applovin/AppLovinAdapter-10.3.7.0.zip)
 - Verified compatibility with AppLovin SDK 10.3.7.
 
 Built and tested with:

--- a/adapters/Facebook/CHANGELOG.md
+++ b/adapters/Facebook/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## Facebook iOS Mediation Adapter Changelog
 
+#### Version 6.9.0.0 (In progress)
+- Verified compatibility with FAN SDK 6.9.0.
+
+Built and tested with
+- Google Mobile Ads SDK version 8.12.0.
+- FAN SDK version 6.9.0.
+
 #### [Version 6.8.0.0](https://dl.google.com/googleadmobadssdk/mediation/ios/facebook/FacebookAdapter-6.8.0.0.zip)
 - Verified compatibility with FAN SDK 6.8.0.
 - Now requires minimum iOS version 10.0.

--- a/adapters/Facebook/CHANGELOG.md
+++ b/adapters/Facebook/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Facebook iOS Mediation Adapter Changelog
 
-#### Version 6.9.0.0 (In progress)
+#### [Version 6.9.0.0](https://dl.google.com/googleadmobadssdk/mediation/ios/facebook/FacebookAdapter-6.9.0.0.zip)
 - Verified compatibility with FAN SDK 6.9.0.
 - For Objective-C apps only, you must now add Swift paths to your target's `Build Settings` to prevent compile errors. See the [developer documentation](https://developers.google.com/admob/ios/mediation/facebook#step_4_additional_code_required) for more details.
 

--- a/adapters/Facebook/CHANGELOG.md
+++ b/adapters/Facebook/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 #### Version 6.9.0.0 (In progress)
 - Verified compatibility with FAN SDK 6.9.0.
+- For Objective-C apps only, you must now add Swift paths to your target's `Build Settings` to prevent compile errors. See the [developer documentation](https://developers.google.com/admob/ios/mediation/facebook#step_4_additional_code_required) for more details.
 
 Built and tested with
 - Google Mobile Ads SDK version 8.12.0.

--- a/adapters/Facebook/FacebookAdapter/GADMAdapterFacebookConstants.h
+++ b/adapters/Facebook/FacebookAdapter/GADMAdapterFacebookConstants.h
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 /// Facebook mediation network adapter version.
-static NSString *const kGADMAdapterFacebookVersion = @"6.8.0.0";
+static NSString *const kGADMAdapterFacebookVersion = @"6.9.0.0";
 
 static NSString *const kGADMAdapterFacebookBiddingPubID = @"placement_id";
 

--- a/adapters/Fyber/CHANGELOG.md
+++ b/adapters/Fyber/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## Fyber iOS Mediation Adapter Changelog
 
+#### Version 8.1.1.0 (In progress)
+- Verified compatibility with Fyber Marketplace SDK version 8.1.1.
+
+Built and tested with:
+- Google Mobile Ads SDK version 8.12.0.
+- Fyber Marketplace SDK version 8.1.1.
+
 #### [Version 8.1.0.0](https://dl.google.com/googleadmobadssdk/mediation/ios/fyber/FyberAdapter-8.1.0.0.zip)
 - Verified compatibility with Fyber Marketplace SDK version 8.1.0.
 

--- a/adapters/Fyber/CHANGELOG.md
+++ b/adapters/Fyber/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Fyber iOS Mediation Adapter Changelog
 
-#### Version 8.1.1.0 (In progress)
+#### [Version 8.1.1.0](https://dl.google.com/googleadmobadssdk/mediation/ios/fyber/FyberAdapter-8.1.1.0.zip)
 - Verified compatibility with Fyber Marketplace SDK version 8.1.1.
 
 Built and tested with:

--- a/adapters/Fyber/FyberAdapter/GADMAdapterFyberConstants.h
+++ b/adapters/Fyber/FyberAdapter/GADMAdapterFyberConstants.h
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 /// Fyber mediation adapter version.
-static NSString* const _Nonnull kGADMAdapterFyberVersion = @"8.1.0.0";
+static NSString* const _Nonnull kGADMAdapterFyberVersion = @"8.1.1.0";
 
 /// Fyber mediation adapter app ID key.
 static NSString* const _Nonnull kGADMAdapterFyberApplicationID = @"applicationId";

--- a/adapters/MoPub/MoPubAdapter/GADMAdapterMoPubSingleton.m
+++ b/adapters/MoPub/MoPubAdapter/GADMAdapterMoPubSingleton.m
@@ -120,14 +120,14 @@
 
 - (void)rewardedAdDidLoadForAdUnitID:(NSString *)adUnitID {
   id<MPRewardedAdsDelegate> delegate = [self getDelegateForAdUnitID:adUnitID];
-  if (delegate) {
+  if ([delegate respondsToSelector:@selector(rewardedAdDidLoadForAdUnitID:)]) {
     [delegate rewardedAdDidLoadForAdUnitID:adUnitID];
   }
 }
 
 - (void)rewardedAdDidFailToLoadForAdUnitID:(NSString *)adUnitID error:(NSError *)error {
   id<MPRewardedAdsDelegate> delegate = [self getDelegateForAdUnitID:adUnitID];
-  if (delegate) {
+  if ([delegate respondsToSelector:@selector(rewardedAdDidFailToLoadForAdUnitID:error:)]) {
     [self removeDelegateForAdUnitID:adUnitID];
     [delegate rewardedAdDidFailToLoadForAdUnitID:adUnitID error:error];
   }
@@ -135,28 +135,28 @@
 
 - (void)rewardedAdWillPresentForAdUnitID:(NSString *)adUnitID {
   id<MPRewardedAdsDelegate> delegate = [self getDelegateForAdUnitID:adUnitID];
-  if (delegate) {
+  if ([delegate respondsToSelector:@selector(rewardedAdWillPresentForAdUnitID:)]) {
     [delegate rewardedAdWillPresentForAdUnitID:adUnitID];
   }
 }
 
 - (void)rewardedAdDidPresentForAdUnitID:(NSString *)adUnitID {
   id<MPRewardedAdsDelegate> delegate = [self getDelegateForAdUnitID:adUnitID];
-  if (delegate) {
+  if ([delegate respondsToSelector:@selector(rewardedAdDidPresentForAdUnitID:)]) {
     [delegate rewardedAdDidPresentForAdUnitID:adUnitID];
   }
 }
 
 - (void)rewardedAdWillDismissForAdUnitID:(NSString *)adUnitID {
   id<MPRewardedAdsDelegate> delegate = [self getDelegateForAdUnitID:adUnitID];
-  if (delegate) {
+  if ([delegate respondsToSelector:@selector(rewardedAdWillDismissForAdUnitID:)]) {
     [delegate rewardedAdWillDismissForAdUnitID:adUnitID];
   }
 }
 
 - (void)rewardedAdDidDismissForAdUnitID:(NSString *)adUnitID {
   id<MPRewardedAdsDelegate> delegate = [self getDelegateForAdUnitID:adUnitID];
-  if (delegate) {
+  if ([delegate respondsToSelector:@selector(rewardedAdDidDismissForAdUnitID:)]) {
     [self removeDelegateForAdUnitID:adUnitID];
     [delegate rewardedAdDidDismissForAdUnitID:adUnitID];
   }
@@ -164,7 +164,7 @@
 
 - (void)rewardedAdDidExpireForAdUnitID:(NSString *)adUnitID {
   id<MPRewardedAdsDelegate> delegate = [self getDelegateForAdUnitID:adUnitID];
-  if (delegate) {
+  if ([delegate respondsToSelector:@selector(rewardedAdDidExpireForAdUnitID:)]) {
     [self removeDelegateForAdUnitID:adUnitID];
     [delegate rewardedAdDidExpireForAdUnitID:adUnitID];
   }
@@ -172,21 +172,21 @@
 
 - (void)rewardedAdDidReceiveTapEventForAdUnitID:(NSString *)adUnitID {
   id<MPRewardedAdsDelegate> delegate = [self getDelegateForAdUnitID:adUnitID];
-  if (delegate) {
+  if ([delegate respondsToSelector:@selector(rewardedAdDidReceiveTapEventForAdUnitID:)]) {
     [delegate rewardedAdDidReceiveTapEventForAdUnitID:adUnitID];
   }
 }
 
 - (void)rewardedAdWillLeaveApplicationForAdUnitID:(NSString *)adUnitID {
   id<MPRewardedAdsDelegate> delegate = [self getDelegateForAdUnitID:adUnitID];
-  if (delegate) {
+  if ([delegate respondsToSelector:@selector(rewardedAdWillLeaveApplicationForAdUnitID:)]) {
     [delegate rewardedAdWillLeaveApplicationForAdUnitID:adUnitID];
   }
 }
 
 - (void)rewardedAdShouldRewardForAdUnitID:(NSString *)adUnitID reward:(MPReward *)reward {
   id<MPRewardedAdsDelegate> delegate = [self getDelegateForAdUnitID:adUnitID];
-  if (delegate) {
+  if ([delegate respondsToSelector:@selector(rewardedAdShouldRewardForAdUnitID:reward:)]) {
     [delegate rewardedAdShouldRewardForAdUnitID:adUnitID reward:reward];
   }
 }

--- a/adapters/Vungle/CHANGELOG.md
+++ b/adapters/Vungle/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Vungle iOS Mediation Adapter Changelog
 
-#### Version 6.10.4.0 (In progress)
+#### [Version 6.10.4.0](https://dl.google.com/googleadmobadssdk/mediation/ios/vungle/VungleAdapter-6.10.4.0.zip)
 - Verified compatibility with Vungle SDK 6.10.4.
 - Updated the adapter to respect the mute setting in Vungle's publisher dashboard when the `muteIsSet` boolean in `VungleAdNetworkExtras` is not explicitly set.
 

--- a/adapters/Vungle/CHANGELOG.md
+++ b/adapters/Vungle/CHANGELOG.md
@@ -1,5 +1,13 @@
 ## Vungle iOS Mediation Adapter Changelog
 
+#### Version 6.10.4.0 (In progress)
+- Verified compatibility with Vungle SDK 6.10.4.
+- Updated the adapter to respect the mute setting in Vungle's publisher dashboard when the `muteIsSet` boolean in `VungleAdNetworkExtras` is not explicitly set.
+
+Built and tested with
+- Google Mobile Ads SDK version 8.12.0.
+- Vungle SDK version 6.10.4
+
 #### [Version 6.10.3.1](https://dl.google.com/googleadmobadssdk/mediation/ios/vungle/VungleAdapter-6.10.3.1.zip)
 - Fixed a bug where interstitial callbacks were not invoked after the first playback.
 - Updated the `options` dictionary that is passed into `playAd` method to include the muted property set by the publisher in the extras object.

--- a/adapters/Vungle/Public/Headers/VungleAdNetworkExtras.h
+++ b/adapters/Vungle/Public/Headers/VungleAdNetworkExtras.h
@@ -41,4 +41,6 @@
 
 @property(nonatomic, copy, readonly) NSString *_Nonnull UUID;
 
+@property (nonatomic, readonly, assign) BOOL muteIsSet;
+
 @end

--- a/adapters/Vungle/VungleAdapter.xcodeproj/project.pbxproj
+++ b/adapters/Vungle/VungleAdapter.xcodeproj/project.pbxproj
@@ -35,6 +35,8 @@
 /* Begin PBXBuildFile section */
 		00802E53248848850077C6D0 /* GADMAdapterVungleBanner.h in Headers */ = {isa = PBXBuildFile; fileRef = 00802E51248848850077C6D0 /* GADMAdapterVungleBanner.h */; };
 		00802E54248848850077C6D0 /* GADMAdapterVungleBanner.m in Sources */ = {isa = PBXBuildFile; fileRef = 00802E52248848850077C6D0 /* GADMAdapterVungleBanner.m */; };
+		17C5009526CC5BC300300418 /* GADMAdapterVungleNativeAd.m in Sources */ = {isa = PBXBuildFile; fileRef = 17C5009326CC5BC300300418 /* GADMAdapterVungleNativeAd.m */; };
+		17C5009626CC5BC300300418 /* GADMAdapterVungleNativeAd.h in Headers */ = {isa = PBXBuildFile; fileRef = 17C5009426CC5BC300300418 /* GADMAdapterVungleNativeAd.h */; };
 		407621A123F140B800C18557 /* VungleRouterConfiguration.m in Sources */ = {isa = PBXBuildFile; fileRef = 4076219F23F140B800C18557 /* VungleRouterConfiguration.m */; };
 		407621A223F140B800C18557 /* VungleRouterConfiguration.h in Headers */ = {isa = PBXBuildFile; fileRef = 407621A023F140B800C18557 /* VungleRouterConfiguration.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		4552392A20B6381E0081388F /* VungleRouterConsent.m in Sources */ = {isa = PBXBuildFile; fileRef = 4552392720B6381D0081388F /* VungleRouterConsent.m */; };
@@ -91,6 +93,8 @@
 		00802E51248848850077C6D0 /* GADMAdapterVungleBanner.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GADMAdapterVungleBanner.h; sourceTree = "<group>"; };
 		00802E52248848850077C6D0 /* GADMAdapterVungleBanner.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = GADMAdapterVungleBanner.m; sourceTree = "<group>"; };
 		00DD26AB22F10DD20039C1D4 /* Script_Validate.sh */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.sh; path = Script_Validate.sh; sourceTree = "<group>"; };
+		17C5009326CC5BC300300418 /* GADMAdapterVungleNativeAd.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GADMAdapterVungleNativeAd.m; sourceTree = "<group>"; };
+		17C5009426CC5BC300300418 /* GADMAdapterVungleNativeAd.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GADMAdapterVungleNativeAd.h; sourceTree = "<group>"; };
 		4076219F23F140B800C18557 /* VungleRouterConfiguration.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = VungleRouterConfiguration.m; sourceTree = "<group>"; };
 		407621A023F140B800C18557 /* VungleRouterConfiguration.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = VungleRouterConfiguration.h; sourceTree = "<group>"; };
 		4552392720B6381D0081388F /* VungleRouterConsent.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = VungleRouterConsent.m; sourceTree = "<group>"; };
@@ -156,6 +160,8 @@
 				45BFFB5822272D1000C96A67 /* GADMediationAdapterVungle.m */,
 				A85428DD1F11853A00C135E7 /* VungleAdNetworkExtras.m */,
 				4552392720B6381D0081388F /* VungleRouterConsent.m */,
+				17C5009426CC5BC300300418 /* GADMAdapterVungleNativeAd.h */,
+				17C5009326CC5BC300300418 /* GADMAdapterVungleNativeAd.m */,
 			);
 			path = VungleAdapter;
 			sourceTree = "<group>";
@@ -234,6 +240,7 @@
 				A85428E01F11853A00C135E7 /* GADMAdapterVungleInterstitial.h in Headers */,
 				45BFFB5D22272D4300C96A67 /* GADMAdapterVungleRewardedAd.h in Headers */,
 				4557855B238DE7E700523142 /* GADMAdapterVungleDelegate.h in Headers */,
+				17C5009626CC5BC300300418 /* GADMAdapterVungleNativeAd.h in Headers */,
 				458F734F2385DFF2006738A0 /* GADMAdapterVungleRouter.h in Headers */,
 				7D1575721EB7FBB200059469 /* VungleAdapter.h in Headers */,
 				56C4F0F21F29531200BABF7E /* VungleAdNetworkExtras.h in Headers */,
@@ -349,6 +356,7 @@
 				A85428E31F11853A00C135E7 /* GADMAdapterVungleRewardBasedVideoAd.m in Sources */,
 				407621A123F140B800C18557 /* VungleRouterConfiguration.m in Sources */,
 				4593F490227CE28A00F57AE5 /* GADMAdapterVungleUtils.m in Sources */,
+				17C5009526CC5BC300300418 /* GADMAdapterVungleNativeAd.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/adapters/Vungle/VungleAdapter/GADMAdapterVungleConstants.h
+++ b/adapters/Vungle/VungleAdapter/GADMAdapterVungleConstants.h
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-static NSString *const _Nonnull kGADMAdapterVungleVersion = @"6.10.3.1";
+static NSString *const _Nonnull kGADMAdapterVungleVersion = @"6.10.4.0";
 static NSString *const _Nonnull kGADMAdapterVungleApplicationID = @"application_id";
 static NSString *const _Nonnull kGADMAdapterVunglePlacementID = @"placementID";
 static NSString *const _Nonnull kGADMAdapterVungleErrorDomain = @"com.google.mediation.vungle";

--- a/adapters/Vungle/VungleAdapter/GADMAdapterVungleNativeAd.h
+++ b/adapters/Vungle/VungleAdapter/GADMAdapterVungleNativeAd.h
@@ -1,0 +1,27 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import <Foundation/Foundation.h>
+#import <GoogleMobileAds/GoogleMobileAds.h>
+
+@interface GADMAdapterVungleNativeAd : NSObject
+
+/// Asks the receiver to render the ad configuration.
+- (nonnull instancetype)initNativeAdForAdConfiguration:(nonnull GADMediationNativeAdConfiguration *)adConfiguration
+                                     completionHandler:(nonnull GADMediationNativeLoadCompletionHandler)completionHandler;
+- (nonnull instancetype)init NS_UNAVAILABLE;
+- (void)requestAd;
+
+@end
+

--- a/adapters/Vungle/VungleAdapter/GADMAdapterVungleNativeAd.m
+++ b/adapters/Vungle/VungleAdapter/GADMAdapterVungleNativeAd.m
@@ -1,0 +1,243 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import "GADMAdapterVungleNativeAd.h"
+#include <stdatomic.h>
+#import "GADMAdapterVungleUtils.h"
+#import "GADMAdapterVungleRouter.h"
+#import <VungleSDK/VungleNativeAd.h>
+
+@interface GADMAdapterVungleNativeAd () <GADMediationNativeAd, VungleNativeAdDelegate, GADMAdapterVungleDelegate>
+
+@end
+
+@implementation GADMAdapterVungleNativeAd {
+  /// Ad configuration for the ad to be loaded.
+  GADMediationNativeAdConfiguration *_adConfiguration;
+
+  /// The completion handler to call when the ad loading succeeds or fails.
+  GADMediationNativeLoadCompletionHandler _adLoadCompletionHandler;
+
+  /// The Vungle native ad.
+  VungleNativeAd *_nativeAd;
+
+  /// The ad event delegate to forward ad rendering events to the Google Mobile Ads SDK.
+  id<GADMediationNativeAdEventDelegate> _delegate;
+    
+  VungleMediaView *_mediaView;
+}
+
+@synthesize desiredPlacement;
+
+- (nonnull instancetype)initNativeAdForAdConfiguration:(nonnull GADMediationNativeAdConfiguration *)adConfiguration
+                                     completionHandler:(nonnull GADMediationNativeLoadCompletionHandler)completionHandler {
+  self = [super init];
+  if (self) {
+    _adConfiguration = adConfiguration;
+
+    // Store the ad config and completion handler for later use.
+    __block atomic_flag adLoadHandlerCalled = ATOMIC_FLAG_INIT;
+    __block GADMediationNativeLoadCompletionHandler originalCompletionHandler = [completionHandler copy];
+
+    // Ensure the original completion handler is only called once, and is deallocated once called.
+    _adLoadCompletionHandler = ^id<GADMediationNativeAdEventDelegate>(_Nullable id<GADMediationNativeAd> ad, NSError *_Nullable error) {
+      if (atomic_flag_test_and_set(&adLoadHandlerCalled)) {
+        return nil;
+      }
+      id<GADMediationNativeAdEventDelegate> delegate = nil;
+      if (originalCompletionHandler) {
+        delegate = originalCompletionHandler(ad, error);
+      }
+      originalCompletionHandler = nil;
+      return delegate;
+    };
+  }
+  return self;
+}
+
+- (void)requestAd {
+  self.desiredPlacement = [GADMAdapterVungleUtils findPlacement:_adConfiguration.credentials.settings
+                                                  networkExtras:_adConfiguration.extras];
+  if (!self.desiredPlacement) {
+    NSError *error = GADMAdapterVungleErrorWithCodeAndDescription(GADMAdapterVungleErrorInvalidServerParameters, @"Placement ID not specified.");
+    _adLoadCompletionHandler(nil, error);
+    return;
+  }
+    
+  if (![[VungleSDK sharedSDK] isInitialized]) {
+    NSString *appID = [GADMAdapterVungleUtils findAppID:_adConfiguration.credentials.settings];
+    [[GADMAdapterVungleRouter sharedInstance] initWithAppId:appID delegate:self];
+    return;
+  }
+    
+  if ([[GADMAdapterVungleRouter sharedInstance] isSDKInitialized]) {
+    [self loadAd];
+    return;
+  }
+    
+  NSString *appID = [GADMAdapterVungleUtils findAppID:_adConfiguration.credentials.settings];
+  [[GADMAdapterVungleRouter sharedInstance] initWithAppId:appID delegate:self];
+}
+
+- (void)loadAd {
+  _nativeAd = [[VungleNativeAd alloc] initWithPlacementID:self.desiredPlacement];
+  _nativeAd.delegate = self;
+  [_nativeAd loadAd];
+}
+
+#pragma mark - GADMediatedUnifiedNativeAd
+
+- (nullable NSString *)headline {
+    return _nativeAd.title;
+}
+
+- (nullable NSArray<GADNativeAdImage *> *)images {
+  return nil;
+}
+
+- (nullable NSString *)body {
+    return _nativeAd.bodyText;
+}
+
+- (nullable GADNativeAdImage *)icon {
+    return [[GADNativeAdImage alloc] initWithImage:_nativeAd.iconImage];
+}
+
+- (nullable NSString *)callToAction {
+    return _nativeAd.callToAction;
+}
+
+- (nullable NSDecimalNumber *)starRating {
+  return [[NSDecimalNumber alloc] initWithDouble:_nativeAd.adStarRating];
+}
+
+- (nullable NSString *)store {
+  return nil;
+}
+
+- (nullable NSString *)price {
+  return nil;
+}
+
+- (nullable NSString *)advertiser {
+  return nil;
+}
+
+- (nullable NSDictionary<NSString *, id> *)extraAssets {
+  return nil;
+}
+
+- (nullable UIView *)adChoicesView {
+  return nil;
+}
+
+- (nullable UIView *)mediaView {
+  return _mediaView;
+}
+
+- (BOOL)hasVideoContent {
+  return YES;
+}
+
+- (void)didRenderInView:(nonnull UIView *)view
+    clickableAssetViews:(nonnull NSDictionary<GADNativeAssetIdentifier, UIView *> *)clickableAssetViews
+ nonclickableAssetViews:(nonnull NSDictionary<GADNativeAssetIdentifier, UIView *> *)nonclickableAssetViews
+         viewController:(nonnull UIViewController *)viewController {
+  NSArray<UIView *> *assets = clickableAssetViews.allValues;
+  UIImageView *iconView = nil;
+  if ([clickableAssetViews[GADNativeIconAsset] isKindOfClass:[UIImageView class]]) {
+    iconView = (UIImageView *)clickableAssetViews[GADNativeIconAsset];
+  }
+    
+  [_nativeAd registerViewForInteraction:view mediaView:_mediaView iconImageView:iconView viewController:viewController clickableViews:assets];
+}
+
+- (void)didUntrackView:(nullable UIView *)view {
+  [_nativeAd unregisterView];
+}
+
+#pragma mark - VungleNativeAdDelegate
+
+- (void)nativeAdDidLoad:(VungleNativeAd *)nativeAd {
+  if (_delegate) {
+    // Already invoked an ad load callback.
+    return;
+  }
+
+  _mediaView = [[VungleMediaView alloc] init];
+  _delegate = _adLoadCompletionHandler(self, nil);
+}
+
+- (void)nativeAd:(VungleNativeAd *)nativeAd didFailWithError:(NSError *)error {
+  _adLoadCompletionHandler(nil, error);
+}
+
+- (void)nativeAdDidClick:(VungleNativeAd *)nativeAd {
+  [_delegate reportClick];
+}
+
+- (void)nativeAdDidTrackImpression:(VungleNativeAd *)nativeAd {
+  [_delegate reportImpression];
+}
+
+#pragma mark - GADMAdapterVungleDelegate
+
+- (void)initialized:(BOOL)isSuccess error:(nullable NSError *)error {
+  if (isSuccess) {
+    // Native ads are object based. Don't need the Router to manage the delegates except for lazy initialization
+    GADMAdapterVungleNativeAd __weak *weakSelf = self;
+    [[GADMAdapterVungleRouter sharedInstance] removeDelegate:weakSelf];
+    [self loadAd];
+  } else {
+    _adLoadCompletionHandler(nil, error);
+  }
+}
+
+- (void)adAvailable {
+    // Do nothing. Native ads utilize a different set of callbacks.
+}
+
+- (void)adNotAvailable:(nonnull NSError *)error {
+    // Do nothing. Native ads utilize a different set of callbacks.
+}
+
+- (void)didCloseAd {
+    // Do nothing. Native ads utilize a different set of callbacks.
+}
+
+- (void)didViewAd {
+    // Do nothing. Native ads utilize a different set of callbacks.
+}
+
+- (void)rewardUser {
+    // Do nothing. Native ads utilize a different set of callbacks.
+}
+
+- (void)trackClick {
+    // Do nothing. Native ads utilize a different set of callbacks.
+}
+
+- (void)willCloseAd {
+    // Do nothing. Native ads utilize a different set of callbacks.
+}
+
+- (void)willLeaveApplication {
+    // Do nothing. Native ads utilize a different set of callbacks.
+}
+
+- (void)willShowAd {
+    // Do nothing. Native ads utilize a different set of callbacks.
+}
+
+@end

--- a/adapters/Vungle/VungleAdapter/GADMAdapterVungleRewardedAd.m
+++ b/adapters/Vungle/VungleAdapter/GADMAdapterVungleRewardedAd.m
@@ -83,21 +83,13 @@
     return;
   }
 
-  VungleSDK *sdk = [VungleSDK sharedSDK];
-
-  if ([sdk isInitialized]) {
-    [self loadRewardedAd];
+  if (![[VungleSDK sharedSDK] isInitialized]) {
+    NSString *appID = [GADMAdapterVungleUtils findAppID:_adConfiguration.credentials.settings];
+    [[GADMAdapterVungleRouter sharedInstance] initWithAppId:appID delegate:self];
     return;
   }
-
-  NSString *appID = [GADMAdapterVungleUtils findAppID:_adConfiguration.credentials.settings];
-  if (!appID) {
-    NSError *error = GADMAdapterVungleErrorWithCodeAndDescription(
-        GADMAdapterVungleErrorInvalidServerParameters, @"Vungle app ID not specified.");
-    _adLoadCompletionHandler(nil, error);
-    return;
-  }
-  [[GADMAdapterVungleRouter sharedInstance] initWithAppId:appID delegate:self];
+    
+  [self loadRewardedAd];
 }
 
 - (void)loadRewardedAd {

--- a/adapters/Vungle/VungleAdapter/GADMAdapterVungleRouter.h
+++ b/adapters/Vungle/VungleAdapter/GADMAdapterVungleRouter.h
@@ -37,5 +37,6 @@ extern const CGSize kVNGBannerShortSize;
                                     extras:(nullable VungleAdNetworkExtras *)extras
                             forPlacementID:(nonnull NSString *)placementID;
 - (void)completeBannerAdViewForPlacementID:(nonnull id<GADMAdapterVungleDelegate>)delegate;
+- (BOOL)isSDKInitialized;
 
 @end

--- a/adapters/Vungle/VungleAdapter/GADMAdapterVungleRouter.m
+++ b/adapters/Vungle/VungleAdapter/GADMAdapterVungleRouter.m
@@ -335,8 +335,11 @@ static NSString *const _Nonnull kGADMAdapterVungleNullPubRequestID = @"null";
   NSMutableDictionary *options = nil;
   if (extras) {
     options = [[NSMutableDictionary alloc] init];
-    GADMAdapterVungleMutableDictionarySetObjectForKey(options, VunglePlayAdOptionKeyStartMuted,
-                                                      @(extras.muted));
+      
+    if (extras.muteIsSet) {
+      GADMAdapterVungleMutableDictionarySetObjectForKey(options, VunglePlayAdOptionKeyStartMuted,
+                                                        @(extras.muted));
+    }
     if (extras.userId) {
       GADMAdapterVungleMutableDictionarySetObjectForKey(options, VunglePlayAdOptionKeyUser,
                                                         extras.userId);
@@ -375,8 +378,10 @@ static NSString *const _Nonnull kGADMAdapterVungleNullPubRequestID = @"null";
   NSMutableDictionary *options = nil;
   if (extras) {
     options = [[NSMutableDictionary alloc] init];
-    GADMAdapterVungleMutableDictionarySetObjectForKey(options, VunglePlayAdOptionKeyStartMuted,
-                                                      @(extras.muted));
+    if (extras.muteIsSet) {
+      GADMAdapterVungleMutableDictionarySetObjectForKey(options, VunglePlayAdOptionKeyStartMuted,
+                                                        @(extras.muted));
+    }
     if (extras.userId) {
       GADMAdapterVungleMutableDictionarySetObjectForKey(options, VunglePlayAdOptionKeyUser,
                                                         extras.userId);

--- a/adapters/Vungle/VungleAdapter/GADMAdapterVungleRouter.m
+++ b/adapters/Vungle/VungleAdapter/GADMAdapterVungleRouter.m
@@ -93,6 +93,13 @@ static NSString *const _Nonnull kGADMAdapterVungleNullPubRequestID = @"null";
   if (_isInitializing) {
     return;
   }
+    
+  if (!appId) {
+    NSError *error = GADMAdapterVungleErrorWithCodeAndDescription(
+      GADMAdapterVungleErrorInvalidServerParameters, @"Vungle app ID not specified.");
+    [delegate initialized:NO error:error];
+    return;
+  }
 
   _isInitializing = YES;
 

--- a/adapters/Vungle/VungleAdapter/GADMediationAdapterVungle.m
+++ b/adapters/Vungle/VungleAdapter/GADMediationAdapterVungle.m
@@ -14,6 +14,7 @@
 
 #import "GADMediationAdapterVungle.h"
 #import "GADMAdapterVungleConstants.h"
+#import "GADMAdapterVungleNativeAd.h"
 #import "GADMAdapterVungleRewardedAd.h"
 #import "GADMAdapterVungleRouter.h"
 #import "GADMAdapterVungleUtils.h"
@@ -22,6 +23,9 @@
 @implementation GADMediationAdapterVungle {
   /// Vungle rewarded ad wrapper.
   GADMAdapterVungleRewardedAd *_rewardedAd;
+    
+  /// Vungle native ad wrapper
+  GADMAdapterVungleNativeAd *_nativeAd;
 }
 
 + (void)setUpWithConfiguration:(nonnull GADMediationServerConfiguration *)configuration
@@ -92,6 +96,13 @@
   _rewardedAd = [[GADMAdapterVungleRewardedAd alloc] initWithAdConfiguration:adConfiguration
                                                            completionHandler:completionHandler];
   [_rewardedAd requestRewardedAd];
+}
+
+- (void)loadNativeAdForAdConfiguration:(nonnull GADMediationNativeAdConfiguration *)adConfiguration
+                     completionHandler:(nonnull GADMediationNativeLoadCompletionHandler)completionHandler {
+    _nativeAd = [[GADMAdapterVungleNativeAd alloc] initNativeAdForAdConfiguration:adConfiguration
+                                                                completionHandler:completionHandler];
+    [_nativeAd requestAd];
 }
 
 @end

--- a/adapters/Vungle/VungleAdapter/VungleAdNetworkExtras.m
+++ b/adapters/Vungle/VungleAdapter/VungleAdNetworkExtras.m
@@ -14,14 +14,34 @@
 
 #import "VungleAdNetworkExtras.h"
 
+@interface VungleAdNetworkExtras ()
+
+@property (readwrite, assign) BOOL muteIsSet;
+
+@end
+
 @implementation VungleAdNetworkExtras
+
+@synthesize muted = _muted;
 
 - (nonnull instancetype)init {
   self = [super init];
   if (self) {
     _UUID = [[NSUUID UUID] UUIDString];
+    _muteIsSet = NO;
   }
   return self;
+}
+
+-(BOOL)muted
+{
+    return _muted;
+}
+
+-(void)setMuted:(BOOL)muted
+{
+    _muted = muted;
+    self.muteIsSet = YES;
 }
 
 @end


### PR DESCRIPTION
Native Ad implementation.

Testing ticket: [IOS-4438](https://vungle.atlassian.net/browse/IOS-4438)

Endpoint: QA
AppID: 61444db7823f8fe13f7964f0
Placement: NATIVETEST1-9380471
Header: X-Vungle-RTB-ID:5fd219d7c80cb9051249a6ab

To test, set endpoint to QA and build locally. Use Charles to add the RTB header.