### PR TITLE
[IOS-4305] Checking if the delegate in the map table is the delegate wanting to be removed

### DIFF
--- a/adapters/Vungle/VungleAdapter/GADMAdapterVungleRouter.m
+++ b/adapters/Vungle/VungleAdapter/GADMAdapterVungleRouter.m
@@ -251,7 +251,7 @@ static NSString *const _Nonnull kGADMAdapterVungleNullPubRequestID = @"null";
     }
   } else {
     @synchronized(_delegates) {
-      if (delegate && [_delegates objectForKey:delegate.desiredPlacement]) {
+      if (delegate && (delegate == [_delegates objectForKey:delegate.desiredPlacement])) {
         GADMAdapterVungleMapTableRemoveObjectForKey(_delegates, delegate.desiredPlacement);
       }
     }


### PR DESCRIPTION
Checking if the delegate in the map table is the delegate wanting to be removed. This is already done for banners and this prevents any order of operations issues for interstitials/rewarded ad units.

IOS-4305