### PR TITLE
[IOS-4436] Updating adapter to not write the muted flag in the play options if it was never set by the publisher.

### DIFF
--- a/adapters/Vungle/Public/Headers/VungleAdNetworkExtras.h
+++ b/adapters/Vungle/Public/Headers/VungleAdNetworkExtras.h
@@ -41,4 +41,6 @@
 
 @property(nonatomic, copy, readonly) NSString *_Nonnull UUID;
 
+@property (nonatomic, readonly, assign) BOOL muteIsSet;
+
 @end

--- a/adapters/Vungle/VungleAdapter/GADMAdapterVungleRouter.m
+++ b/adapters/Vungle/VungleAdapter/GADMAdapterVungleRouter.m
@@ -335,8 +335,11 @@ static NSString *const _Nonnull kGADMAdapterVungleNullPubRequestID = @"null";
   NSMutableDictionary *options = nil;
   if (extras) {
     options = [[NSMutableDictionary alloc] init];
-    GADMAdapterVungleMutableDictionarySetObjectForKey(options, VunglePlayAdOptionKeyStartMuted,
-                                                      @(extras.muted));
+      
+    if (extras.muteIsSet) {
+      GADMAdapterVungleMutableDictionarySetObjectForKey(options, VunglePlayAdOptionKeyStartMuted,
+                                                        @(extras.muted));
+    }
     if (extras.userId) {
       GADMAdapterVungleMutableDictionarySetObjectForKey(options, VunglePlayAdOptionKeyUser,
                                                         extras.userId);
@@ -375,8 +378,10 @@ static NSString *const _Nonnull kGADMAdapterVungleNullPubRequestID = @"null";
   NSMutableDictionary *options = nil;
   if (extras) {
     options = [[NSMutableDictionary alloc] init];
-    GADMAdapterVungleMutableDictionarySetObjectForKey(options, VunglePlayAdOptionKeyStartMuted,
-                                                      @(extras.muted));
+    if (extras.muteIsSet) {
+      GADMAdapterVungleMutableDictionarySetObjectForKey(options, VunglePlayAdOptionKeyStartMuted,
+                                                        @(extras.muted));
+    }
     if (extras.userId) {
       GADMAdapterVungleMutableDictionarySetObjectForKey(options, VunglePlayAdOptionKeyUser,
                                                         extras.userId);

--- a/adapters/Vungle/VungleAdapter/VungleAdNetworkExtras.m
+++ b/adapters/Vungle/VungleAdapter/VungleAdNetworkExtras.m
@@ -14,14 +14,34 @@
 
 #import "VungleAdNetworkExtras.h"
 
+@interface VungleAdNetworkExtras ()
+
+@property (readwrite, assign) BOOL muteIsSet;
+
+@end
+
 @implementation VungleAdNetworkExtras
+
+@synthesize muted = _muted;
 
 - (nonnull instancetype)init {
   self = [super init];
   if (self) {
     _UUID = [[NSUUID UUID] UUIDString];
+    _muteIsSet = NO;
   }
   return self;
+}
+
+-(BOOL)muted
+{
+    return _muted;
+}
+
+-(void)setMuted:(BOOL)muted
+{
+    _muted = muted;
+    self.muteIsSet = YES;
 }
 
 @end


### PR DESCRIPTION
Updating adapter to not write the muted flag in the play options if it was never set by the publisher.

IOS-4436