### PR TITLE
[IOS-4517] Adding the didShow callback to the VungleDelegate and utilizing the callback to call the Google didStartVideo.

### DIFF
--- a/adapters/Vungle/VungleAdapter/Bidding/GADMediationVungleBanner.m
+++ b/adapters/Vungle/VungleAdapter/Bidding/GADMediationVungleBanner.m
@@ -215,6 +215,10 @@
   self.bannerState = BannerRouterDelegateStatePlaying;
 }
 
+- (void)didShowAd {
+  // Do nothing.
+}
+
 - (void)didViewAd {
   // Do nothing.
 }

--- a/adapters/Vungle/VungleAdapter/Bidding/GADMediationVungleInterstitial.m
+++ b/adapters/Vungle/VungleAdapter/Bidding/GADMediationVungleInterstitial.m
@@ -160,6 +160,10 @@
   [_delegate willPresentFullScreenView];
 }
 
+- (void)didShowAd {
+  // Do nothing.
+}
+
 - (void)didViewAd {
   // Do nothing.
 }

--- a/adapters/Vungle/VungleAdapter/Bidding/GADMediationVungleNativeAd.m
+++ b/adapters/Vungle/VungleAdapter/Bidding/GADMediationVungleNativeAd.m
@@ -206,7 +206,11 @@
     // Do nothing. Native ads utilize a different set of callbacks.
 }
 
-- (void)didCloseAd {
+- (void)willShowAd {
+    // Do nothing. Native ads utilize a different set of callbacks.
+}
+
+- (void)didShowAd {
     // Do nothing. Native ads utilize a different set of callbacks.
 }
 
@@ -226,12 +230,16 @@
     // Do nothing. Native ads utilize a different set of callbacks.
 }
 
+- (void)didCloseAd {
+    // Do nothing. Native ads utilize a different set of callbacks.
+}
+
 - (void)willLeaveApplication {
     // Do nothing. Native ads utilize a different set of callbacks.
 }
 
-- (void)willShowAd {
-    // Do nothing. Native ads utilize a different set of callbacks.
+- (nullable NSString *)bidResponse {
+    return [_adConfiguration bidResponse];
 }
 
 @end

--- a/adapters/Vungle/VungleAdapter/Bidding/GADMediationVungleRewardedAd.m
+++ b/adapters/Vungle/VungleAdapter/Bidding/GADMediationVungleRewardedAd.m
@@ -162,6 +162,10 @@
 - (void)willShowAd {
   id<GADMediationRewardedAdEventDelegate> strongDelegate = _delegate;
   [strongDelegate willPresentFullScreenView];
+}
+
+- (void)didShowAd {
+  id<GADMediationRewardedAdEventDelegate> strongDelegate = _delegate;
   [strongDelegate didStartVideo];
 }
 

--- a/adapters/Vungle/VungleAdapter/GADMAdapterVungleBanner.m
+++ b/adapters/Vungle/VungleAdapter/GADMAdapterVungleBanner.m
@@ -199,6 +199,10 @@
   self.bannerState = BannerRouterDelegateStatePlaying;
 }
 
+- (void)didShowAd {
+  // Do nothing
+}
+
 - (void)didViewAd {
   // Do nothing.
 }

--- a/adapters/Vungle/VungleAdapter/GADMAdapterVungleDelegate.h
+++ b/adapters/Vungle/VungleAdapter/GADMAdapterVungleDelegate.h
@@ -36,6 +36,7 @@ typedef NS_ENUM(NSUInteger, BannerRouterDelegateState) {
 - (void)adAvailable;
 - (void)adNotAvailable:(nonnull NSError *)error;
 - (void)willShowAd;
+- (void)didShowAd;
 - (void)didViewAd;
 - (void)willCloseAd;
 - (void)didCloseAd;

--- a/adapters/Vungle/VungleAdapter/GADMAdapterVungleInterstitial.m
+++ b/adapters/Vungle/VungleAdapter/GADMAdapterVungleInterstitial.m
@@ -183,6 +183,10 @@
   [_connector adapterWillPresentInterstitial:self];
 }
 
+- (void)didShowAd {
+  // Do nothing.
+}
+
 - (void)didViewAd {
   // Do nothing.
 }

--- a/adapters/Vungle/VungleAdapter/GADMAdapterVungleRouter.m
+++ b/adapters/Vungle/VungleAdapter/GADMAdapterVungleRouter.m
@@ -466,7 +466,14 @@ static NSString *const _Nonnull kGADMAdapterVungleNullPubRequestID = @"null";
 }
 
 - (void)vungleDidShowAdForPlacementID:(nullable NSString *)placementID {
-  NSLog(@"Vungle: Did show Ad for placement ID:%@", placementID);
+  if (!placementID.length) {
+    return;
+  }
+
+  id<GADMAdapterVungleDelegate> delegate =
+      [self getDelegateForPlacement:placementID
+          withBannerRouterDelegateState:BannerRouterDelegateStatePlaying];
+  [delegate didShowAd];
 }
 
 - (void)vungleAdViewedForPlacement:(NSString *)placementID {


### PR DESCRIPTION
Adding the didShow callback to the VungleDelegate and utilizing the callback to call the Google didStartVideo.

IOS-4517

Only the rewarded format utilizes the didShow callback; the other formats have no action. I tested this with the Simulator by placing a breakpoint on the didShow callback in the rewarded ads class to test that it is invoked.