### PR TITLE
[IOS-4570] Updating adapter to consume the native ad options position in the network extras object.

### DIFF
--- a/adapters/Vungle/Public/Headers/VungleAdNetworkExtras.h
+++ b/adapters/Vungle/Public/Headers/VungleAdNetworkExtras.h
@@ -43,4 +43,6 @@
 
 @property (nonatomic, readonly, assign) BOOL muteIsSet;
 
+@property (nonatomic, assign) NSInteger nativeAdOptionPosition;
+
 @end

--- a/adapters/Vungle/VungleAdapter/Bidding/GADMediationVungleNativeAd.m
+++ b/adapters/Vungle/VungleAdapter/Bidding/GADMediationVungleNativeAd.m
@@ -35,6 +35,7 @@
   /// The ad event delegate to forward ad rendering events to the Google Mobile Ads SDK.
   id<GADMediationNativeAdEventDelegate> _delegate;
     
+  /// The Vungle container for the main ad
   VungleMediaView *_mediaView;
 }
 
@@ -87,6 +88,10 @@
 - (void)loadAd {
   _nativeAd = [[VungleNativeAd alloc] initWithPlacementID:self.desiredPlacement];
   _nativeAd.delegate = self;
+  VungleAdNetworkExtras *networkExtras = [_adConfiguration extras];
+  if (networkExtras.nativeAdOptionPosition != 0) {
+    _nativeAd.adOptionsPosition = networkExtras.nativeAdOptionPosition;
+  }
   [_nativeAd loadAd];
 }
 

--- a/adapters/Vungle/VungleAdapter/GADMAdapterVungleConstants.h
+++ b/adapters/Vungle/VungleAdapter/GADMAdapterVungleConstants.h
@@ -16,3 +16,5 @@ static NSString *const _Nonnull kGADMAdapterVungleVersion = @"6.11.0.0";
 static NSString *const _Nonnull kGADMAdapterVungleApplicationID = @"application_id";
 static NSString *const _Nonnull kGADMAdapterVunglePlacementID = @"placementID";
 static NSString *const _Nonnull kGADMAdapterVungleErrorDomain = @"com.google.mediation.vungle";
+static NSString *const _Nonnull kVungleNativeAdOptionsPosition = @"adOptionsPosition";
+


### PR DESCRIPTION
Updating adapter to consume the native ad options position in the network extras object.

IOS-4570

Tested in the iOS Simulator with the IOS-4570 branch and a local merge to the native-qa branch (which points the test app to the qa endpoint and changes the ad unit id to one that works since native ads aren't on production yet.