### PR TITLE
[IOS-4566] Updating the native ad to use the sponsoredText as the advertiser.

### DIFF
--- a/adapters/Vungle/VungleAdapter/Bidding/GADMediationVungleNativeAd.m
+++ b/adapters/Vungle/VungleAdapter/Bidding/GADMediationVungleNativeAd.m
@@ -125,7 +125,7 @@
 }
 
 - (nullable NSString *)advertiser {
-  return nil;
+  return _nativeAd.sponsoredText;
 }
 
 - (nullable NSDictionary<NSString *, id> *)extraAssets {


### PR DESCRIPTION
Updating the native ad to use the sponsoredText as the advertiser.

IOS-4566