### PR TITLE
[IOS-4628] Preventing delegate being removed from tracker if auto-cache fails to load next ad.

### DIFF
--- a/adapters/Vungle/VungleAdapter/Bidding/GADMediationVungleBanner.m
+++ b/adapters/Vungle/VungleAdapter/Bidding/GADMediationVungleBanner.m
@@ -33,9 +33,6 @@
   /// The requested ad size.
   GADAdSize _bannerSize;
 
-  /// Indicates whether a banner ad is loaded.
-  BOOL _isAdLoaded;
-
   /// Indicates whether the banner ad finished presenting.
   BOOL _didBannerFinishPresenting;
 }
@@ -46,6 +43,7 @@
 @synthesize isRefreshedForBannerAd;
 @synthesize isRequestingBannerAdForRefresh;
 @synthesize view;
+@synthesize isAdLoaded;
 
 - (void)dealloc {
     [self cleanUp];
@@ -179,11 +177,11 @@
 }
 
 - (void)adAvailable {
-  if (_isAdLoaded) {
+  if (self.isAdLoaded) {
     // Already invoked an ad load callback.
     return;
   }
-  _isAdLoaded = YES;
+  self.isAdLoaded = YES;
   [self loadFrame];
     
   if (_adLoadCompletionHandler) {
@@ -204,7 +202,7 @@
 }
 
 - (void)adNotAvailable:(nonnull NSError *)error {
-  if (_isAdLoaded) {
+  if (self.isAdLoaded) {
     // Already invoked an ad load callback.
     return;
   }

--- a/adapters/Vungle/VungleAdapter/Bidding/GADMediationVungleInterstitial.m
+++ b/adapters/Vungle/VungleAdapter/Bidding/GADMediationVungleInterstitial.m
@@ -30,12 +30,10 @@
 
   /// The ad event delegate to forward ad rendering events to the Google Mobile Ads SDK.
   id<GADMediationInterstitialAdEventDelegate> _delegate;
-
-  /// Indicates whether an interstitial ad is loaded.
-  BOOL _isAdLoaded;
 }
 
 @synthesize desiredPlacement;
+@synthesize isAdLoaded;
 
 #pragma mark - GADMediationVungleInterstitial Methods
 
@@ -132,11 +130,11 @@
 }
 
 - (void)adAvailable {
-  if (_isAdLoaded) {
+  if (self.isAdLoaded) {
     // Already invoked an ad load callback.
     return;
   }
-  _isAdLoaded = YES;
+  self.isAdLoaded = YES;
     
   if (_adLoadCompletionHandler) {
     _delegate = _adLoadCompletionHandler(self, nil);
@@ -149,7 +147,7 @@
 }
 
 - (void)adNotAvailable:(nonnull NSError *)error {
-  if (_isAdLoaded) {
+  if (self.isAdLoaded) {
     // Already invoked an ad load callback.
     return;
   }

--- a/adapters/Vungle/VungleAdapter/Bidding/GADMediationVungleRewardedAd.m
+++ b/adapters/Vungle/VungleAdapter/Bidding/GADMediationVungleRewardedAd.m
@@ -30,12 +30,10 @@
 
   /// The ad event delegate to forward ad rendering events to the Google Mobile Ads SDK.
   id<GADMediationRewardedAdEventDelegate> _delegate;
-
-  /// Indicates whether the rewarded ad is loaded.
-  BOOL _isAdLoaded;
 }
 
 @synthesize desiredPlacement;
+@synthesize isAdLoaded;
 
 - (nonnull instancetype)
     initWithAdConfiguration:(nonnull GADMediationRewardedAdConfiguration *)adConfiguration
@@ -132,11 +130,11 @@
 }
 
 - (void)adAvailable {
-  if (_isAdLoaded) {
+  if (self.isAdLoaded) {
     // Already invoked an ad load callback.
     return;
   }
-  _isAdLoaded = YES;
+  self.isAdLoaded = YES;
 
   if (_adLoadCompletionHandler) {
     _delegate = _adLoadCompletionHandler(self, nil);
@@ -170,7 +168,7 @@
 }
 
 - (void)adNotAvailable:(nonnull NSError *)error {
-  if (_isAdLoaded) {
+  if (self.isAdLoaded) {
     // Already invoked an ad load callback.
     return;
   }

--- a/adapters/Vungle/VungleAdapter/GADMAdapterVungleBanner.m
+++ b/adapters/Vungle/VungleAdapter/GADMAdapterVungleBanner.m
@@ -29,9 +29,6 @@
   /// The requested ad size.
   GADAdSize _bannerSize;
 
-  /// Indicates whether a banner ad is loaded.
-  BOOL _isAdLoaded;
-
   /// Indicates whether the banner ad finished presenting.
   BOOL _didBannerFinishPresenting;
 }
@@ -41,6 +38,7 @@
 @synthesize uniquePubRequestID;
 @synthesize isRefreshedForBannerAd;
 @synthesize isRequestingBannerAdForRefresh;
+@synthesize isAdLoaded;
 
 - (nonnull instancetype)initWithGADMAdNetworkConnector:(nonnull id<GADMAdNetworkConnector>)connector
                                                adapter:(nonnull id<GADMAdNetworkAdapter>)adapter {
@@ -166,11 +164,11 @@
     return;
   }
 
-  if (_isAdLoaded) {
+  if (self.isAdLoaded) {
     // Already invoked an ad load callback.
     return;
   }
-  _isAdLoaded = YES;
+  self.isAdLoaded = YES;
   UIView *bannerView = [[UIView alloc]
       initWithFrame:CGRectMake(0, 0, _bannerSize.size.width, _bannerSize.size.height)];
   NSError *bannerViewError =
@@ -188,7 +186,7 @@
 }
 
 - (void)adNotAvailable:(nonnull NSError *)error {
-  if (_isAdLoaded) {
+  if (self.isAdLoaded) {
     // Already invoked an ad load callback.
     return;
   }
@@ -217,7 +215,7 @@
 
 - (void)trackClick {
   [_connector adapterDidGetAdClick:_adapter];
-  [_connector adapterWillPresentFullScreenModal:_adapter];
+//  [_connector adapterWillPresentFullScreenModal:_adapter];
 }
 
 - (void)willLeaveApplication {

--- a/adapters/Vungle/VungleAdapter/GADMAdapterVungleDelegate.h
+++ b/adapters/Vungle/VungleAdapter/GADMAdapterVungleDelegate.h
@@ -29,6 +29,9 @@ typedef NS_ENUM(NSUInteger, BannerRouterDelegateState) {
 /// Placement ID used to request an ad from Vungle.
 @property(nonatomic, copy, nonnull) NSString *desiredPlacement;
 
+/// Indicates whether the ad has been loaded successfully.
+@property(nonatomic) BOOL isAdLoaded;
+
 /// Bid Response when the ad is instantiated. May be null if bidding is not enabled.
 - (nullable NSString *)bidResponse;
 

--- a/adapters/Vungle/VungleAdapter/GADMAdapterVungleInterstitial.m
+++ b/adapters/Vungle/VungleAdapter/GADMAdapterVungleInterstitial.m
@@ -28,9 +28,6 @@
 
   /// Vungle banner ad wrapper.
   GADMAdapterVungleBanner *_bannerAd;
-
-  /// Indicates whether an interstitial ad is loaded.
-  BOOL _isAdLoaded;
 }
 
 // Redirect to the main adapter class for bidding
@@ -146,6 +143,7 @@
 #pragma mark - GADMAdapterVungleDelegate
 
 @synthesize desiredPlacement;
+@synthesize isAdLoaded;
 
 - (nullable NSString *)bidResponse {
     // This is the waterfall interstitial section. It won't have a bid response
@@ -161,17 +159,17 @@
 }
 
 - (void)adAvailable {
-  if (_isAdLoaded) {
+  if (self.isAdLoaded) {
     // Already invoked an ad load callback.
     return;
   }
-  _isAdLoaded = YES;
+    self.isAdLoaded = YES;
 
   [_connector adapterDidReceiveInterstitial:self];
 }
 
 - (void)adNotAvailable:(nonnull NSError *)error {
-  if (_isAdLoaded) {
+  if (self.isAdLoaded) {
     // Already invoked an ad load callback.
     return;
   }

--- a/adapters/Vungle/VungleAdapter/GADMAdapterVungleRouter.m
+++ b/adapters/Vungle/VungleAdapter/GADMAdapterVungleRouter.m
@@ -534,6 +534,14 @@ static NSString *const _Nonnull kGADMAdapterVungleNullPubRequestID = @"null";
   if ([[VungleSDK sharedSDK] isAdCachedForPlacementID:placementID adMarkup:[delegate bidResponse]]) {
     return;
   }
+    
+  // Vungle SDK calls this method for auto-cached placements after playing the ad.
+  // If the next placement fails to download the ad, then the SDK would call this method
+  // with isAdPlayable NO. If the delegate is already loaded, do not remove it from the
+  // tracker because the call is for the next ad.
+  if ([delegate isAdLoaded]) {
+    return;
+  }
 
   // Ad not playable. Return an error.
   if (error) {


### PR DESCRIPTION
Fixing issue where delegate is removed from the tracker if the placement is auto-cached and the next ad fails to load.
If the delegate has already been loaded, then it should not be removed if the next ad fails to auto-load.

IOS-4628