### PR TITLE
Updating constant name and fixing a warning.

### DIFF
--- a/adapters/Vungle/VungleAdapter/Bidding/GADMediationVungleNativeAd.m
+++ b/adapters/Vungle/VungleAdapter/Bidding/GADMediationVungleNativeAd.m
@@ -40,6 +40,7 @@
 }
 
 @synthesize desiredPlacement;
+@synthesize isAdLoaded;
 
 - (nonnull instancetype)initNativeAdForAdConfiguration:(nonnull GADMediationNativeAdConfiguration *)adConfiguration
                                      completionHandler:(nonnull GADMediationNativeLoadCompletionHandler)completionHandler {

--- a/adapters/Vungle/VungleAdapter/GADMAdapterVungleConstants.h
+++ b/adapters/Vungle/VungleAdapter/GADMAdapterVungleConstants.h
@@ -16,4 +16,4 @@ static NSString *const _Nonnull GADMAdapterVungleVersion = @"6.11.0.2";
 static NSString *const _Nonnull GADMAdapterVungleApplicationID = @"application_id";
 static NSString *const _Nonnull GADMAdapterVunglePlacementID = @"placementID";
 static NSString *const _Nonnull GADMAdapterVungleErrorDomain = @"com.google.mediation.vungle";
-static NSString *const _Nonnull kVungleNativeAdOptionsPosition = @"adOptionsPosition";
+static NSString *const _Nonnull GADMAdapterVungleNativeAdOptionsPosition = @"adOptionsPosition";


### PR DESCRIPTION
This commit will fix a constant name and a warning after the rebase of 6.11 to the upstream change.