### PR TITLE
[IOS-5700] This commit fixes possible issues noticed during the documentation update.

### DIFF
--- a/adapters/Vungle/VungleAdapter/Bidding/GADMediationVungleInterstitial.m
+++ b/adapters/Vungle/VungleAdapter/Bidding/GADMediationVungleInterstitial.m
@@ -141,7 +141,7 @@
 }
 
 - (void)interstitialAdDidTrackImpression:(VungleInterstitial *)interstitial {
-  // No-op.
+  [_delegate reportImpression];
 }
 
 - (void)interstitialAdDidClick:(VungleInterstitial *)interstitial {


### PR DESCRIPTION
This commit adds a report impression callback for bidding interstitial that Google pointed out in the 6.x PR. 
This commit brings back a set to fire delegates in case the publisher attempts to lazy initialize multiple ad units at once.

IOS-5700