### PR TITLE
Return MREC ad size for fluid banner size

### DIFF
--- a/adapters/LiftoffMonetize/LiftoffMonetizeAdapter/GADMAdapterVungleBanner.m
+++ b/adapters/LiftoffMonetize/LiftoffMonetizeAdapter/GADMAdapterVungleBanner.m
@@ -61,7 +61,7 @@
   if (!strongConnector || !strongAdapter) {
     return;
   }
-
+  NSLog(@"[FLUID BANNER TESTING - Adapter] Requested banner size received by adapter - width: %f and height: %f", adSize.size.width, adSize.size.height);
   _bannerSize = GADMAdapterVungleAdSizeForAdSize(adSize);
   if (!IsGADAdSizeValid(_bannerSize)) {
     NSString *errorMessage =
@@ -92,11 +92,21 @@
   [_bannerAd load:nil];
 }
 
+- (CGSize)updateBannerViewSizeIfNeeded {
+    if (GADAdSizeEqualToSize(_bannerSize, GADAdSizeFluid)) {
+        NSLog(@"[FLUID BANNER TESTING - Adapter] BannerView size has to be updated to allow presentation without errors from VungleSDK");
+        return CGSizeMake(300, 250);
+    }
+    return _bannerSize.size;
+}
+
 #pragma mark - VungleBannerDelegate
 
 - (void)bannerAdDidLoad:(nonnull VungleBanner *)banner {
+    CGSize updatedBannerSize = [self updateBannerViewSizeIfNeeded];
   _bannerView = [[UIView alloc]
-      initWithFrame:CGRectMake(0, 0, _bannerSize.size.width, _bannerSize.size.height)];
+      initWithFrame:CGRectMake(0, 0, updatedBannerSize.width, updatedBannerSize.height)];
+    NSLog(@"[FLUID BANNER TESTING - Adapter] BannerView size *RIGHT* before SDK present called - width(%f) and height(%f)", _bannerView.frame.size.width, _bannerView.frame.size.height);
   [_bannerAd presentOn:_bannerView];
 }
 

--- a/adapters/LiftoffMonetize/LiftoffMonetizeAdapter/GADMAdapterVungleUtils.m
+++ b/adapters/LiftoffMonetize/LiftoffMonetizeAdapter/GADMAdapterVungleUtils.m
@@ -27,12 +27,18 @@ NSError *_Nonnull GADMAdapterVungleErrorWithCodeAndDescription(GADMAdapterVungle
 
 const CGSize kVNGBannerShortSize = {300, 50};
 GADAdSize GADMAdapterVungleAdSizeForAdSize(GADAdSize adSize) {
-  if ((adSize.size.height >= GADAdSizeMediumRectangle.size.height &&
-      adSize.size.width >= GADAdSizeMediumRectangle.size.width) || 
-      (adSize.size.height == 0 && adSize.size.width == 0)) {
+//  if ((adSize.size.height >= GADAdSizeMediumRectangle.size.height &&
+//      adSize.size.width >= GADAdSizeMediumRectangle.size.width) || 
+//      (adSize.size.height == 0 && adSize.size.width == 0)) {
+  if (adSize.size.height >= GADAdSizeMediumRectangle.size.height &&
+      adSize.size.width >= GADAdSizeMediumRectangle.size.width) {
       // VungleSDK will return MREC ad for 300 X 250 and greater OR
       // for 0,0 provided sizes
     return GADAdSizeMediumRectangle;
+  }
+  
+  if ((adSize.size.height == 0 && adSize.size.width == 0)) {
+      return GADAdSizeFluid;
   }
 
   // An array of supported ad sizes.
@@ -57,7 +63,8 @@ GADAdSize GADMAdapterVungleAdSizeForAdSize(GADAdSize adSize) {
 }
 
 BannerSize GADMAdapterVungleConvertGADAdSizeToBannerSize(GADAdSize adSize) {
-  if (GADAdSizeEqualToSize(adSize, GADAdSizeMediumRectangle)) {
+  if (GADAdSizeEqualToSize(adSize, GADAdSizeMediumRectangle) ||
+      GADAdSizeEqualToSize(adSize, GADAdSizeFluid)) {
     return BannerSizeMrec;
   }
   if (adSize.size.height == GADAdSizeLeaderboard.size.height) {


### PR DESCRIPTION
With GAM support of fluid banner sizes (providing 0,0 as the banner size for the ad to be requested), this change will allow for the VungleSDK to request an MREC ad when the fluid size is included in the ad load request.

IOS-6609