### PR TITLE
[IOS-7024] Update privacy icon position handling

### DIFF
--- a/adapters/LiftoffMonetize/LiftoffMonetizeAdapter/Bidding/GADMediationVungleNativeAd.m
+++ b/adapters/LiftoffMonetize/LiftoffMonetizeAdapter/Bidding/GADMediationVungleNativeAd.m
@@ -100,17 +100,17 @@
   [_nativeAd setWithExtras:extras];
   VungleAdNetworkExtras *networkExtras = _adConfiguration.extras;
   switch (networkExtras.nativeAdOptionPosition) {
-    case 1:
-      _nativeAd.adOptionsPosition = NativeAdOptionsPositionTopLeft;
-      break;
-    case 2:
+    case GADAdChoicesPositionTopRightCorner:
       _nativeAd.adOptionsPosition = NativeAdOptionsPositionTopRight;
       break;
-    case 3:
-      _nativeAd.adOptionsPosition = NativeAdOptionsPositionBottomLeft;
+    case GADAdChoicesPositionTopLeftCorner:
+      _nativeAd.adOptionsPosition = NativeAdOptionsPositionTopLeft;
       break;
-    case 4:
+    case GADAdChoicesPositionBottomRightCorner:
       _nativeAd.adOptionsPosition = NativeAdOptionsPositionBottomRight;
+      break;
+    case GADAdChoicesPositionBottomLeftCorner:
+      _nativeAd.adOptionsPosition = NativeAdOptionsPositionBottomLeft;
       break;
     default:
       _nativeAd.adOptionsPosition = NativeAdOptionsPositionTopRight;

--- a/adapters/LiftoffMonetize/Public/Headers/VungleAdNetworkExtras.h
+++ b/adapters/LiftoffMonetize/Public/Headers/VungleAdNetworkExtras.h
@@ -26,9 +26,10 @@
 @property(nonatomic, copy) NSString *_Nullable playingPlacement;
 
 /*!
- * @brief NSInteger that will be passed to alter the privacy icon position for native ads.
- * @discussion Optional. topLeft = 1, topRight = 2, bottomLeft = 3, bottomRight = 4
+ * @brief GAAdChoicesPosition enum that will be passed to alter the privacy icon position for
+ * native ads.
+ * @discussion Optional. topRight = 0, topLeft = 1, bottomRight = 2, bottomLeft = 3
  */
-@property(nonatomic, assign) NSInteger nativeAdOptionPosition;
+@property(nonatomic, assign) GADAdChoicesPosition nativeAdOptionPosition;
 
 @end


### PR DESCRIPTION
This commit updates the privacy icon position handling to take into consideration the differences between the GAAdChoicesPosition enum and the NativeAdOptionsPosition enum.

IOS-7024