### PR TITLE
[IOS-7024] Fix typo in network extras documentation

### DIFF
--- a/adapters/LiftoffMonetize/Public/Headers/VungleAdNetworkExtras.h
+++ b/adapters/LiftoffMonetize/Public/Headers/VungleAdNetworkExtras.h
@@ -26,7 +26,7 @@
 @property(nonatomic, copy) NSString *_Nullable playingPlacement;
 
 /*!
- * @brief GAAdChoicesPosition enum that will be passed to alter the privacy icon position for
+ * @brief GADAdChoicesPosition enum that will be passed to alter the privacy icon position for
  * native ads.
  * @discussion Optional. topRight = 0, topLeft = 1, bottomRight = 2, bottomLeft = 3
  */


### PR DESCRIPTION
This commit fixes a typo in VungleAdNetworkExtras documentation, updating so GADAdChoicesPosition is referenced correctly.

IOS-7024