### PR TITLE
[IOS-7042] Update Native Ad dealloc cleanup

### DIFF
--- a/adapters/LiftoffMonetize/LiftoffMonetizeAdapter/Bidding/GADMediationVungleNativeAd.m
+++ b/adapters/LiftoffMonetize/LiftoffMonetizeAdapter/Bidding/GADMediationVungleNativeAd.m
@@ -43,12 +43,9 @@
 @synthesize desiredPlacement;
 
 - (void)dealloc {
-    __weak typeof(self) weakSelf = self;
     [NSThread isMainThread] ? [self cleanupResources] : dispatch_async(dispatch_get_main_queue(), ^{
-        __strong typeof(weakSelf) strongSelf = weakSelf;
-        [strongSelf cleanupResources];
+        [self cleanupResources];
     });
-
 }
 
 - (void)cleanupResources {

--- a/adapters/LiftoffMonetize/LiftoffMonetizeAdapter/Bidding/GADMediationVungleNativeAd.m
+++ b/adapters/LiftoffMonetize/LiftoffMonetizeAdapter/Bidding/GADMediationVungleNativeAd.m
@@ -43,11 +43,20 @@
 @synthesize desiredPlacement;
 
 - (void)dealloc {
-  _adConfiguration = nil;
-  _adLoadCompletionHandler = nil;
-  _delegate = nil;
-  _mediaView = nil;
-  _nativeAd = nil;
+    __weak typeof(self) weakSelf = self;
+    [NSThread isMainThread] ? [self cleanupResources] : dispatch_async(dispatch_get_main_queue(), ^{
+        __strong typeof(weakSelf) strongSelf = weakSelf;
+        [strongSelf cleanupResources];
+    });
+
+}
+
+- (void)cleanupResources {
+    _adConfiguration = nil;
+    _adLoadCompletionHandler = nil;
+    _delegate = nil;
+    _mediaView = nil;
+    _nativeAd = nil;
 }
 
 - (nonnull instancetype)


### PR DESCRIPTION
This commit updates the Native Ad dealloc to execute resource
cleanup on the main thread. Changes are made based on pub
reported crash.

Verified changes using the ad mob adapter test app. No issues 
found when native ad is dismissed or removed from view.

[IOS-7042](https://vungle.atlassian.net/browse/IOS-7042)

[IOS-7042]: https://vungle.atlassian.net/browse/IOS-7042?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ