### PR TITLE
[IOS-7949] Adapter Logging

### DIFF
--- a/AdapterUnitTests/LiftoffMonetizeAdapterTests/AUTLiftoffMonetizeAppOpenAdTests.m
+++ b/AdapterUnitTests/LiftoffMonetizeAdapterTests/AUTLiftoffMonetizeAppOpenAdTests.m
@@ -140,6 +140,7 @@ static NSString *const kBidResponse = @"bidResponse";
   OCMExpect([_appOpenMock setDelegate:[OCMArg any]]).andDo(^(NSInvocation *invocation) {
     [invocation getArgument:&loadDelegate atIndex:2];
   });
+  OCMExpect([_appOpenMock setAdapterAdFormat:@"GADMediationVungleAppOpenAd"]);
   OCMExpect([_appOpenMock load:kBidResponse]).andDo(^(NSInvocation *invocation) {
     [loadDelegate interstitialAdDidLoad:self->_appOpenMock];
   });
@@ -195,6 +196,7 @@ static NSString *const kBidResponse = @"bidResponse";
   OCMExpect([_appOpenMock setDelegate:[OCMArg any]]).andDo(^(NSInvocation *invocation) {
     [invocation getArgument:&loadDelegate atIndex:2];
   });
+  OCMExpect([_appOpenMock setAdapterAdFormat:@"GADMediationVungleAppOpenAd"]);
   OCMExpect([_appOpenMock load:nil]).andDo(^(NSInvocation *invocation) {
     [loadDelegate interstitialAdDidLoad:self->_appOpenMock];
   });

--- a/AdapterUnitTests/LiftoffMonetizeAdapterTests/AUTLiftoffMonetizeBannerAdTests.m
+++ b/AdapterUnitTests/LiftoffMonetizeAdapterTests/AUTLiftoffMonetizeBannerAdTests.m
@@ -128,6 +128,7 @@ static NSString *const kBidResponse = @"bidResponse";
   OCMExpect([_bannerMock setDelegate:[OCMArg any]]).andDo(^(NSInvocation *invocation) {
     [invocation getArgument:&loadDelegate atIndex:2];
   });
+  OCMExpect([_bannerMock setAdapterAdFormat:@"GADMediationVungleBanner"]);
   OCMExpect([_bannerMock load:kBidResponse]).andDo(^(NSInvocation *invocation) {
     [loadDelegate bannerAdDidLoad:self->_bannerMock];
   });

--- a/AdapterUnitTests/LiftoffMonetizeAdapterTests/AUTLiftoffMonetizeInterstitialAdTests.m
+++ b/AdapterUnitTests/LiftoffMonetizeAdapterTests/AUTLiftoffMonetizeInterstitialAdTests.m
@@ -126,6 +126,7 @@ static NSString *const kBidResponse = @"bidResponse";
   OCMExpect([_interstitialMock setDelegate:[OCMArg any]]).andDo(^(NSInvocation *invocation) {
     [invocation getArgument:&loadDelegate atIndex:2];
   });
+  OCMExpect([_interstitialMock setAdapterAdFormat:@"GADMediationVungleInterstitial"]);
   OCMExpect([_interstitialMock load:kBidResponse]).andDo(^(NSInvocation *invocation) {
     [loadDelegate interstitialAdDidLoad:self->_interstitialMock];
   });

--- a/AdapterUnitTests/LiftoffMonetizeAdapterTests/AUTLiftoffMonetizeNativeAdTests.m
+++ b/AdapterUnitTests/LiftoffMonetizeAdapterTests/AUTLiftoffMonetizeNativeAdTests.m
@@ -128,6 +128,7 @@ static NSString *const kBidResponse = @"bidResponse";
   OCMExpect([_nativeMock setDelegate:[OCMArg any]]).andDo(^(NSInvocation *invocation) {
     [invocation getArgument:&loadDelegate atIndex:2];
   });
+  OCMExpect([_nativeMock setAdapterAdFormat:@"GADMediationVungleNativeAd"]);
   OCMExpect([_nativeMock setAdOptionsPosition:expectedNativeAdPosition]);
   OCMExpect([_nativeMock load:kBidResponse]).andDo(^(NSInvocation *invocation) {
     [loadDelegate nativeAdDidLoad:self->_nativeMock];

--- a/AdapterUnitTests/LiftoffMonetizeAdapterTests/AUTLiftoffMonetizeRTBRewardedAdTests.m
+++ b/AdapterUnitTests/LiftoffMonetizeAdapterTests/AUTLiftoffMonetizeRTBRewardedAdTests.m
@@ -130,6 +130,7 @@ static NSString *const kBidResponse = @"bidResponse";
   OCMExpect([_rewardedMock setDelegate:[OCMArg any]]).andDo(^(NSInvocation *invocation) {
     [invocation getArgument:&loadDelegate atIndex:2];
   });
+  OCMExpect([_rewardedMock setAdapterAdFormat:@"GADMediationVungleRewardedAd"]);
   OCMExpect([_rewardedMock load:kBidResponse]).andDo(^(NSInvocation *invocation) {
     [loadDelegate rewardedAdDidLoad:self->_rewardedMock];
   });

--- a/AdapterUnitTests/LiftoffMonetizeAdapterTests/AUTLiftoffMonetizeUtilsTests.m
+++ b/AdapterUnitTests/LiftoffMonetizeAdapterTests/AUTLiftoffMonetizeUtilsTests.m
@@ -1,7 +1,10 @@
 #import "GADMAdapterVungleUtils.h"
 #import "GADMAdapterVungleConstants.h"
 
+#import <OCMock/OCMock.h>
+#import <VungleAdsSDK/VungleAdsSDK.h>
 #import <XCTest/XCTest.h>
+#import <objc/runtime.h>
 
 static NSString* const kPlacementID = @"12345";
 
@@ -43,7 +46,7 @@ static NSString* const kPlacementID = @"12345";
 - (void)testLiftoffSizeForShortBannerSize {
   const CGSize shortBannerCGSize = {300, 50};
   GADAdSize shortBannerSize = GADAdSizeFromCGSize(shortBannerCGSize);
-    
+
     VungleAdSize* vungleAdSize =
         GADMAdapterVungleConvertGADAdSizeToVungleAdSize(shortBannerSize, kPlacementID);
 
@@ -59,6 +62,33 @@ static NSString* const kPlacementID = @"12345";
   XCTAssertNotNil(vungleAdSize);
   XCTAssertEqual(vungleAdSize.size.width, GADAdSizeSkyscraper.size.width);
   XCTAssertEqual(vungleAdSize.size.height, GADAdSizeSkyscraper.size.height);
+}
+
+- (void)testLogCustomSizeAppendsCustomSuffixForNonInlineNonStandardSize {
+  // Mock VungleAds isInLine: to return NO.
+  id vungleAdsMock = OCMClassMock([VungleAds class]);
+  OCMStub([vungleAdsMock isInLine:kPlacementID]).andReturn(NO);
+
+  // Swizzle VungleMediationLogger (Swift class, cannot be mocked by OCMock) to a no-op.
+  Method logMethod = class_getClassMethod([VungleMediationLogger class],
+                                          @selector(logErrorForAd:message:));
+  IMP originalIMP = method_getImplementation(logMethod);
+  method_setImplementation(logMethod, imp_implementationWithBlock(^(id self, id ad, NSString *msg) {
+  }));
+
+  id bannerViewMock = OCMClassMock([VungleBannerView class]);
+  OCMStub([bannerViewMock adapterAdFormat]).andReturn(@"GADMediationVungleBanner");
+
+  GADAdSize customSize = GADAdSizeFromCGSize(CGSizeMake(400, 100));
+  [GADMAdapterVungleUtils logCustomSizeForBannerPlacement:kPlacementID
+                                                   adSize:customSize
+                                             bannerViewAd:bannerViewMock];
+
+  OCMVerify([bannerViewMock setAdapterAdFormat:@"GADMediationVungleBanner-custom"]);
+
+  // Restore original implementation.
+  method_setImplementation(logMethod, originalIMP);
+  [vungleAdsMock stopMocking];
 }
 
 @end

--- a/AdapterUnitTests/LiftoffMonetizeAdapterTests/AUTLiftoffMonetizeWaterfallRewardedAdTests.m
+++ b/AdapterUnitTests/LiftoffMonetizeAdapterTests/AUTLiftoffMonetizeWaterfallRewardedAdTests.m
@@ -126,6 +126,7 @@ static NSString *const kUserId = @"UserId";
   OCMExpect([_rewardedMock setDelegate:[OCMArg any]]).andDo(^(NSInvocation *invocation) {
     [invocation getArgument:&loadDelegate atIndex:2];
   });
+  OCMExpect([_rewardedMock setAdapterAdFormat:@"GADMAdapterVungleRewardBasedVideoAd"]);
   OCMExpect([_rewardedMock setUserIdWithUserId:kUserId]);
   OCMExpect([_rewardedMock load:nil]).andDo(^(NSInvocation *invocation) {
     [loadDelegate rewardedAdDidLoad:self->_rewardedMock];

--- a/adapters/LiftoffMonetize/LiftoffMonetizeAdapter/Bidding/GADMediationVungleBanner.m
+++ b/adapters/LiftoffMonetize/LiftoffMonetizeAdapter/Bidding/GADMediationVungleBanner.m
@@ -96,6 +96,8 @@
                                        vungleAdSize:GADMAdapterVungleConvertGADAdSizeToVungleAdSize(
                                                         _bannerSize, self.desiredPlacement)];
   _bannerAdView.delegate = self;
+  _bannerAdView.adapterAdFormat = @"GADMediationVungleBanner";
+  [GADMAdapterVungleUtils logCustomSizeForBannerPlacement:self.desiredPlacement adSize:_bannerSize bannerViewAd:_bannerAdView];
   VungleAdsExtras *extras = [[VungleAdsExtras alloc] init];
   [extras setWithWatermark:[_adConfiguration.watermark base64EncodedStringWithOptions:0]];
   [_bannerAdView setWithExtras:extras];

--- a/adapters/LiftoffMonetize/LiftoffMonetizeAdapter/Bidding/GADMediationVungleBanner.m
+++ b/adapters/LiftoffMonetize/LiftoffMonetizeAdapter/Bidding/GADMediationVungleBanner.m
@@ -96,7 +96,7 @@
                                        vungleAdSize:GADMAdapterVungleConvertGADAdSizeToVungleAdSize(
                                                         _bannerSize, self.desiredPlacement)];
   _bannerAdView.delegate = self;
-  _bannerAdView.adapterAdFormat = @"GADMediationVungleBanner";
+  _bannerAdView.adapterAdFormat = NSStringFromClass(self.class);
   [GADMAdapterVungleUtils logCustomSizeForBannerPlacement:self.desiredPlacement adSize:_bannerSize bannerViewAd:_bannerAdView];
   VungleAdsExtras *extras = [[VungleAdsExtras alloc] init];
   [extras setWithWatermark:[_adConfiguration.watermark base64EncodedStringWithOptions:0]];

--- a/adapters/LiftoffMonetize/LiftoffMonetizeAdapter/Bidding/GADMediationVungleInterstitial.m
+++ b/adapters/LiftoffMonetize/LiftoffMonetizeAdapter/Bidding/GADMediationVungleInterstitial.m
@@ -94,6 +94,7 @@
 - (void)loadAd {
   _interstitialAd = [[VungleInterstitial alloc] initWithPlacementId:self.desiredPlacement];
   _interstitialAd.delegate = self;
+  _interstitialAd.adapterAdFormat = @"GADMediationInterstitialAd";
   VungleAdsExtras *extras = [[VungleAdsExtras alloc] init];
   [extras setWithWatermark:[_adConfiguration.watermark base64EncodedStringWithOptions:0]];
   [_interstitialAd setWithExtras:extras];

--- a/adapters/LiftoffMonetize/LiftoffMonetizeAdapter/Bidding/GADMediationVungleInterstitial.m
+++ b/adapters/LiftoffMonetize/LiftoffMonetizeAdapter/Bidding/GADMediationVungleInterstitial.m
@@ -94,7 +94,7 @@
 - (void)loadAd {
   _interstitialAd = [[VungleInterstitial alloc] initWithPlacementId:self.desiredPlacement];
   _interstitialAd.delegate = self;
-  _interstitialAd.adapterAdFormat = @"GADMediationInterstitialAd";
+  _interstitialAd.adapterAdFormat = @"GADMediationVungleInterstitial";
   VungleAdsExtras *extras = [[VungleAdsExtras alloc] init];
   [extras setWithWatermark:[_adConfiguration.watermark base64EncodedStringWithOptions:0]];
   [_interstitialAd setWithExtras:extras];

--- a/adapters/LiftoffMonetize/LiftoffMonetizeAdapter/Bidding/GADMediationVungleInterstitial.m
+++ b/adapters/LiftoffMonetize/LiftoffMonetizeAdapter/Bidding/GADMediationVungleInterstitial.m
@@ -94,7 +94,7 @@
 - (void)loadAd {
   _interstitialAd = [[VungleInterstitial alloc] initWithPlacementId:self.desiredPlacement];
   _interstitialAd.delegate = self;
-  _interstitialAd.adapterAdFormat = @"GADMediationVungleInterstitial";
+  _interstitialAd.adapterAdFormat = NSStringFromClass(self.class);
   VungleAdsExtras *extras = [[VungleAdsExtras alloc] init];
   [extras setWithWatermark:[_adConfiguration.watermark base64EncodedStringWithOptions:0]];
   [_interstitialAd setWithExtras:extras];

--- a/adapters/LiftoffMonetize/LiftoffMonetizeAdapter/Bidding/GADMediationVungleNativeAd.m
+++ b/adapters/LiftoffMonetize/LiftoffMonetizeAdapter/Bidding/GADMediationVungleNativeAd.m
@@ -96,6 +96,7 @@
 - (void)loadAd {
   _nativeAd = [[VungleNative alloc] initWithPlacementId:self.desiredPlacement];
   _nativeAd.delegate = self;
+  _nativeAd.adapterAdFormat = @"GADMediationVungleNativeAd";
   VungleAdsExtras *extras = [[VungleAdsExtras alloc] init];
   [extras setWithWatermark:[_adConfiguration.watermark base64EncodedStringWithOptions:0]];
   [_nativeAd setWithExtras:extras];

--- a/adapters/LiftoffMonetize/LiftoffMonetizeAdapter/Bidding/GADMediationVungleNativeAd.m
+++ b/adapters/LiftoffMonetize/LiftoffMonetizeAdapter/Bidding/GADMediationVungleNativeAd.m
@@ -96,7 +96,7 @@
 - (void)loadAd {
   _nativeAd = [[VungleNative alloc] initWithPlacementId:self.desiredPlacement];
   _nativeAd.delegate = self;
-  _nativeAd.adapterAdFormat = @"GADMediationVungleNativeAd";
+  _nativeAd.adapterAdFormat = NSStringFromClass(self.class);
   VungleAdsExtras *extras = [[VungleAdsExtras alloc] init];
   [extras setWithWatermark:[_adConfiguration.watermark base64EncodedStringWithOptions:0]];
   [_nativeAd setWithExtras:extras];

--- a/adapters/LiftoffMonetize/LiftoffMonetizeAdapter/Bidding/GADMediationVungleRewardedAd.m
+++ b/adapters/LiftoffMonetize/LiftoffMonetizeAdapter/Bidding/GADMediationVungleRewardedAd.m
@@ -82,6 +82,7 @@
 - (void)loadRewardedAd {
   _rewardedAd = [[VungleRewarded alloc] initWithPlacementId:self.desiredPlacement];
   _rewardedAd.delegate = self;
+  _rewardedAd.adapterAdFormat = @"GADMediationVungleRewardedAd";
   VungleAdsExtras *extras = [[VungleAdsExtras alloc] init];
   [extras setWithWatermark:[_adConfiguration.watermark base64EncodedStringWithOptions:0]];
   [_rewardedAd setWithExtras:extras];

--- a/adapters/LiftoffMonetize/LiftoffMonetizeAdapter/Bidding/GADMediationVungleRewardedAd.m
+++ b/adapters/LiftoffMonetize/LiftoffMonetizeAdapter/Bidding/GADMediationVungleRewardedAd.m
@@ -82,7 +82,7 @@
 - (void)loadRewardedAd {
   _rewardedAd = [[VungleRewarded alloc] initWithPlacementId:self.desiredPlacement];
   _rewardedAd.delegate = self;
-  _rewardedAd.adapterAdFormat = @"GADMediationVungleRewardedAd";
+  _rewardedAd.adapterAdFormat = NSStringFromClass(self.class);
   VungleAdsExtras *extras = [[VungleAdsExtras alloc] init];
   [extras setWithWatermark:[_adConfiguration.watermark base64EncodedStringWithOptions:0]];
   [_rewardedAd setWithExtras:extras];

--- a/adapters/LiftoffMonetize/LiftoffMonetizeAdapter/GADMAdapterVungleConstants.h
+++ b/adapters/LiftoffMonetize/LiftoffMonetizeAdapter/GADMAdapterVungleConstants.h
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-static NSString *const _Nonnull GADMAdapterVungleVersion = @"7.7.0.0";
+static NSString *const _Nonnull GADMAdapterVungleVersion = @"7.7.1.0";
 static NSString *const _Nonnull GADMAdapterVungleApplicationID = @"application_id";
 static NSString *const _Nonnull GADMAdapterVunglePlacementID = @"placementID";
 static NSString *const _Nonnull GADMAdapterVungleErrorDomain = @"com.google.mediation.vungle";

--- a/adapters/LiftoffMonetize/LiftoffMonetizeAdapter/GADMAdapterVungleRewardBasedVideoAd.m
+++ b/adapters/LiftoffMonetize/LiftoffMonetizeAdapter/GADMAdapterVungleRewardBasedVideoAd.m
@@ -95,6 +95,7 @@
 - (void)loadRewardedAd {
   _rewardedAd = [[VungleRewarded alloc] initWithPlacementId:self.desiredPlacement];
   _rewardedAd.delegate = self;
+  _rewardedAd.adapterAdFormat = @"GADMAdapterVungleRewardBasedVideoAd";
   if ([_adConfiguration extras] &&
       [[_adConfiguration extras] isKindOfClass:[VungleAdNetworkExtras class]]) {
     VungleAdNetworkExtras *extras = (VungleAdNetworkExtras *)[_adConfiguration extras];

--- a/adapters/LiftoffMonetize/LiftoffMonetizeAdapter/GADMAdapterVungleRewardBasedVideoAd.m
+++ b/adapters/LiftoffMonetize/LiftoffMonetizeAdapter/GADMAdapterVungleRewardBasedVideoAd.m
@@ -95,7 +95,7 @@
 - (void)loadRewardedAd {
   _rewardedAd = [[VungleRewarded alloc] initWithPlacementId:self.desiredPlacement];
   _rewardedAd.delegate = self;
-  _rewardedAd.adapterAdFormat = @"GADMAdapterVungleRewardBasedVideoAd";
+  _rewardedAd.adapterAdFormat = NSStringFromClass(self.class);
   if ([_adConfiguration extras] &&
       [[_adConfiguration extras] isKindOfClass:[VungleAdNetworkExtras class]]) {
     VungleAdNetworkExtras *extras = (VungleAdNetworkExtras *)[_adConfiguration extras];

--- a/adapters/LiftoffMonetize/LiftoffMonetizeAdapter/GADMAdapterVungleUtils.h
+++ b/adapters/LiftoffMonetize/LiftoffMonetizeAdapter/GADMAdapterVungleUtils.h
@@ -33,6 +33,10 @@ void GADMAdapterVungleMutableSetAddObject(NSMutableSet *_Nullable set, NSObject 
 
 + (nonnull NSString *)findAppID:(nullable NSDictionary *)serverParameters;
 + (nonnull NSString *)findPlacement:(nullable NSDictionary *)serverParameters;
+/// Returns YES if adSize is not a standard GAD size (i.e. adaptive or custom), NO otherwise.
++ (void)logCustomSizeForBannerPlacement:(NSString *_Nonnull)placementId
+                                 adSize:(GADAdSize)adSize
+                           bannerViewAd:(VungleBannerView *_Nullable)adViewAd;
 
 /// Updates the Vungle COPPA status if needed.
 + (void)updateVungleCOPPAStatusIfNeeded;

--- a/adapters/LiftoffMonetize/LiftoffMonetizeAdapter/GADMAdapterVungleUtils.h
+++ b/adapters/LiftoffMonetize/LiftoffMonetizeAdapter/GADMAdapterVungleUtils.h
@@ -33,7 +33,6 @@ void GADMAdapterVungleMutableSetAddObject(NSMutableSet *_Nullable set, NSObject 
 
 + (nonnull NSString *)findAppID:(nullable NSDictionary *)serverParameters;
 + (nonnull NSString *)findPlacement:(nullable NSDictionary *)serverParameters;
-/// Returns YES if adSize is not a standard GAD size (i.e. adaptive or custom), NO otherwise.
 + (void)logCustomSizeForBannerPlacement:(NSString *_Nonnull)placementId
                                  adSize:(GADAdSize)adSize
                            bannerViewAd:(VungleBannerView *_Nullable)adViewAd;

--- a/adapters/LiftoffMonetize/LiftoffMonetizeAdapter/GADMAdapterVungleUtils.m
+++ b/adapters/LiftoffMonetize/LiftoffMonetizeAdapter/GADMAdapterVungleUtils.m
@@ -61,6 +61,53 @@ VungleAdSize *_Nonnull GADMAdapterVungleConvertGADAdSizeToVungleAdSize(
   }
 }
 
++ (void)logCustomSizeForBannerPlacement:(NSString *_Nonnull)placementId
+                                 adSize:(GADAdSize)adSize
+                           bannerViewAd:(VungleBannerView *_Nullable)adViewAd {
+  // For dev, will remove
+  NSString *adSizeName = nil;
+  if (GADAdSizeEqualToSize(adSize, GADAdSizeBanner)) {
+    adSizeName = @"GADAdSizeBanner (320x50)";
+  } else if (GADAdSizeEqualToSize(adSize, GADAdSizeLargeBanner)) {
+    adSizeName = @"GADAdSizeLargeBanner (320x100)";
+  } else if (GADAdSizeEqualToSize(adSize, GADAdSizeMediumRectangle)) {
+    adSizeName = @"GADAdSizeMediumRectangle (300x250)";
+  } else if (GADAdSizeEqualToSize(adSize, GADAdSizeFullBanner)) {
+    adSizeName = @"GADAdSizeFullBanner (468x60)";
+  } else if (GADAdSizeEqualToSize(adSize, GADAdSizeLeaderboard)) {
+    adSizeName = @"GADAdSizeLeaderboard (728x90)";
+  } else if (GADAdSizeEqualToSize(adSize, GADAdSizeSkyscraper)) {
+    adSizeName = @"GADAdSizeSkyscraper (120x600)";
+  } else if (GADAdSizeEqualToSize(adSize, GADAdSizeFluid)) {
+    adSizeName = @"GADAdSizeFluid";
+  } else if (GADAdSizeEqualToSize(adSize, GADAdSizeInvalid)) {
+    adSizeName = @"GADAdSizeInvalid";
+  } else {
+    NSLog(@"--->>> [VungleAdapter] logCustomSizeForBannerPlacement: placementId=%@ adSize=%@ (adaptive/custom)",placementId, NSStringFromGADAdSize(adSize));
+  }
+  NSLog(@"--->>> [VungleAdapter] logCustomSizeForBannerPlacement: placementId=%@ adSize=%@",placementId, adSizeName);
+  // For dev, will remove ---<<<
+
+  if (!GADAdSizeEqualToSize(adSize, GADAdSizeBanner) &&           // 320x50
+      !GADAdSizeEqualToSize(adSize, GADAdSizeLargeBanner) &&      // 320x100 // need to exclude?
+      !GADAdSizeEqualToSize(adSize, GADAdSizeMediumRectangle) &&  // 300x250
+      !GADAdSizeEqualToSize(adSize, GADAdSizeFullBanner) &&       // 468x60  // need to exclude?
+      !GADAdSizeEqualToSize(adSize, GADAdSizeLeaderboard) &&      // 728x90
+      !GADAdSizeEqualToSize(adSize, GADAdSizeSkyscraper) &&       // 120x600 // need to exclude?
+      !GADAdSizeEqualToSize(adSize, GADAdSizeFluid) &&            // fluid (dynamic height) // need to exclude?
+      ![VungleAdSize VungleValidAdSizeFromCGSizeWithSize:adSize.size placementId:placementId]) {
+    // Not a standard size — GADAdSizeInvalid or custom size
+    adViewAd.adapterAdFormat = @"GADMediationVungleBanner-custom";
+    NSString *adaptiveSizeMessage = [NSString stringWithFormat:@"CustomBannerSizeMismatch:w-%.0f|h-%.0f",
+                                     adSize.size.width,
+                                     adSize.size.height];
+    [VungleMediationLogger logErrorForAd:adViewAd message:adaptiveSizeMessage];
+
+    NSLog(@"Please use a Liftoff inline placement ID in order to use custom size banner: placementId=%@ adSize=%@",
+          placementId, NSStringFromGADAdSize(adSize));
+  }
+}
+
 #pragma mark - Safe Collection utility methods.
 
 void GADMAdapterVungleMutableSetAddObject(NSMutableSet *_Nullable set, NSObject *_Nonnull object) {

--- a/adapters/LiftoffMonetize/LiftoffMonetizeAdapter/GADMAdapterVungleUtils.m
+++ b/adapters/LiftoffMonetize/LiftoffMonetizeAdapter/GADMAdapterVungleUtils.m
@@ -63,7 +63,7 @@ VungleAdSize *_Nonnull GADMAdapterVungleConvertGADAdSizeToVungleAdSize(
 
 + (void)logCustomSizeForBannerPlacement:(NSString *_Nonnull)placementId
                                  adSize:(GADAdSize)adSize
-                           bannerViewAd:(VungleBannerView *_Nullable)adViewAd {  // For dev, will remove
+                           bannerViewAd:(VungleBannerView *_Nullable)adViewAd {
   // Not a standard size case — GADAdSizeLargeBanner(320x100), GADAdSizeFullBanner(468x60),
   // GADAdSizeSkyscraper(120x600), GADAdSizeFluid, GADAdSizeInvalid, or custom size
   if (![VungleAds isInLine:placementId] &&

--- a/adapters/LiftoffMonetize/LiftoffMonetizeAdapter/GADMAdapterVungleUtils.m
+++ b/adapters/LiftoffMonetize/LiftoffMonetizeAdapter/GADMAdapterVungleUtils.m
@@ -63,40 +63,14 @@ VungleAdSize *_Nonnull GADMAdapterVungleConvertGADAdSizeToVungleAdSize(
 
 + (void)logCustomSizeForBannerPlacement:(NSString *_Nonnull)placementId
                                  adSize:(GADAdSize)adSize
-                           bannerViewAd:(VungleBannerView *_Nullable)adViewAd {
-  // For dev, will remove
-  NSString *adSizeName = nil;
-  if (GADAdSizeEqualToSize(adSize, GADAdSizeBanner)) {
-    adSizeName = @"GADAdSizeBanner (320x50)";
-  } else if (GADAdSizeEqualToSize(adSize, GADAdSizeLargeBanner)) {
-    adSizeName = @"GADAdSizeLargeBanner (320x100)";
-  } else if (GADAdSizeEqualToSize(adSize, GADAdSizeMediumRectangle)) {
-    adSizeName = @"GADAdSizeMediumRectangle (300x250)";
-  } else if (GADAdSizeEqualToSize(adSize, GADAdSizeFullBanner)) {
-    adSizeName = @"GADAdSizeFullBanner (468x60)";
-  } else if (GADAdSizeEqualToSize(adSize, GADAdSizeLeaderboard)) {
-    adSizeName = @"GADAdSizeLeaderboard (728x90)";
-  } else if (GADAdSizeEqualToSize(adSize, GADAdSizeSkyscraper)) {
-    adSizeName = @"GADAdSizeSkyscraper (120x600)";
-  } else if (GADAdSizeEqualToSize(adSize, GADAdSizeFluid)) {
-    adSizeName = @"GADAdSizeFluid";
-  } else if (GADAdSizeEqualToSize(adSize, GADAdSizeInvalid)) {
-    adSizeName = @"GADAdSizeInvalid";
-  } else {
-    NSLog(@"--->>> [VungleAdapter] logCustomSizeForBannerPlacement: placementId=%@ adSize=%@ (adaptive/custom)",placementId, NSStringFromGADAdSize(adSize));
-  }
-  NSLog(@"--->>> [VungleAdapter] logCustomSizeForBannerPlacement: placementId=%@ adSize=%@",placementId, adSizeName);
-  // For dev, will remove ---<<<
-
-  if (!GADAdSizeEqualToSize(adSize, GADAdSizeBanner) &&           // 320x50
-      !GADAdSizeEqualToSize(adSize, GADAdSizeLargeBanner) &&      // 320x100 // need to exclude?
+                           bannerViewAd:(VungleBannerView *_Nullable)adViewAd {  // For dev, will remove
+  // Not a standard size case — GADAdSizeLargeBanner(320x100), GADAdSizeFullBanner(468x60),
+  // GADAdSizeSkyscraper(120x600), GADAdSizeFluid, GADAdSizeInvalid, or custom size
+  if (![VungleAds isInLine:placementId] &&
+      !GADAdSizeEqualToSize(adSize, GADAdSizeBanner) &&           // 320x50
       !GADAdSizeEqualToSize(adSize, GADAdSizeMediumRectangle) &&  // 300x250
-      !GADAdSizeEqualToSize(adSize, GADAdSizeFullBanner) &&       // 468x60  // need to exclude?
-      !GADAdSizeEqualToSize(adSize, GADAdSizeLeaderboard) &&      // 728x90
-      !GADAdSizeEqualToSize(adSize, GADAdSizeSkyscraper) &&       // 120x600 // need to exclude?
-      !GADAdSizeEqualToSize(adSize, GADAdSizeFluid) &&            // fluid (dynamic height) // need to exclude?
-      ![VungleAdSize VungleValidAdSizeFromCGSizeWithSize:adSize.size placementId:placementId]) {
-    // Not a standard size — GADAdSizeInvalid or custom size
+      !GADAdSizeEqualToSize(adSize, GADAdSizeLeaderboard) ) {      // 728x90
+    
     adViewAd.adapterAdFormat = @"GADMediationVungleBanner-custom";
     NSString *adaptiveSizeMessage = [NSString stringWithFormat:@"CustomBannerSizeMismatch:w-%.0f|h-%.0f",
                                      adSize.size.width,

--- a/adapters/LiftoffMonetize/LiftoffMonetizeAdapter/GADMAdapterVungleUtils.m
+++ b/adapters/LiftoffMonetize/LiftoffMonetizeAdapter/GADMAdapterVungleUtils.m
@@ -71,7 +71,7 @@ VungleAdSize *_Nonnull GADMAdapterVungleConvertGADAdSizeToVungleAdSize(
       !GADAdSizeEqualToSize(adSize, GADAdSizeBanner) &&           // 320x50
       !GADAdSizeEqualToSize(adSize, GADAdSizeMediumRectangle) &&  // 300x250
       !GADAdSizeEqualToSize(adSize, GADAdSizeLeaderboard)) {      // 728x90
-    adViewAd.adapterAdFormat = @"GADMediationVungleBanner-custom";
+    adViewAd.adapterAdFormat = [adViewAd.adapterAdFormat stringByAppendingString:@"-custom"];
     NSString *customSizeMismatchMessage =
         [NSString stringWithFormat:@"CustomBannerSizeMismatch:w-%.0f|h-%.0f",
                                    adSize.size.width, adSize.size.height];

--- a/adapters/LiftoffMonetize/LiftoffMonetizeAdapter/GADMAdapterVungleUtils.m
+++ b/adapters/LiftoffMonetize/LiftoffMonetizeAdapter/GADMAdapterVungleUtils.m
@@ -64,20 +64,20 @@ VungleAdSize *_Nonnull GADMAdapterVungleConvertGADAdSizeToVungleAdSize(
 + (void)logCustomSizeForBannerPlacement:(NSString *_Nonnull)placementId
                                  adSize:(GADAdSize)adSize
                            bannerViewAd:(VungleBannerView *_Nullable)adViewAd {
-  // Not a standard size case — GADAdSizeLargeBanner(320x100), GADAdSizeFullBanner(468x60),
-  // GADAdSizeSkyscraper(120x600), GADAdSizeFluid, GADAdSizeInvalid, or custom size
+  // Size not supported for non-inline placements — may include GADAdSizeLargeBanner (320x100),
+  // GADAdSizeFullBanner (468x60), GADAdSizeSkyscraper (120x600), GADAdSizeFluid,
+  // GADAdSizeInvalid, or a custom size.
   if (![VungleAds isInLine:placementId] &&
       !GADAdSizeEqualToSize(adSize, GADAdSizeBanner) &&           // 320x50
       !GADAdSizeEqualToSize(adSize, GADAdSizeMediumRectangle) &&  // 300x250
-      !GADAdSizeEqualToSize(adSize, GADAdSizeLeaderboard) ) {      // 728x90
-    
+      !GADAdSizeEqualToSize(adSize, GADAdSizeLeaderboard)) {      // 728x90
     adViewAd.adapterAdFormat = @"GADMediationVungleBanner-custom";
-    NSString *adaptiveSizeMessage = [NSString stringWithFormat:@"CustomBannerSizeMismatch:w-%.0f|h-%.0f",
-                                     adSize.size.width,
-                                     adSize.size.height];
-    [VungleMediationLogger logErrorForAd:adViewAd message:adaptiveSizeMessage];
-
-    NSLog(@"Please use a Liftoff inline placement ID in order to use custom size banner: placementId=%@ adSize=%@",
+    NSString *customSizeMismatchMessage =
+        [NSString stringWithFormat:@"CustomBannerSizeMismatch:w-%.0f|h-%.0f",
+                                   adSize.size.width, adSize.size.height];
+    [VungleMediationLogger logErrorForAd:adViewAd message:customSizeMismatchMessage];
+    NSLog(@"Banner size is unsupported for non-inline Liftoff placements. "
+          @"Use a Liftoff inline placement ID to serve this banner size: placementId=%@ adSize=%@",
           placementId, NSStringFromGADAdSize(adSize));
   }
 }

--- a/adapters/LiftoffMonetize/LiftoffMonetizeAdapter/GADMediationVungleAppOpenAd.m
+++ b/adapters/LiftoffMonetize/LiftoffMonetizeAdapter/GADMediationVungleAppOpenAd.m
@@ -90,6 +90,7 @@
 - (void)loadAd {
   _appOpenAd = [[VungleInterstitial alloc] initWithPlacementId:self.desiredPlacement];
   _appOpenAd.delegate = self;
+  _appOpenAd.adapterAdFormat = @"GADMediationVungleAppOpenAd";
   if (_adConfiguration.bidResponse) {
     // If bid response is present, then it is an RTB ad.
     VungleAdsExtras *extras = [[VungleAdsExtras alloc] init];

--- a/adapters/LiftoffMonetize/LiftoffMonetizeAdapter/GADMediationVungleAppOpenAd.m
+++ b/adapters/LiftoffMonetize/LiftoffMonetizeAdapter/GADMediationVungleAppOpenAd.m
@@ -90,7 +90,7 @@
 - (void)loadAd {
   _appOpenAd = [[VungleInterstitial alloc] initWithPlacementId:self.desiredPlacement];
   _appOpenAd.delegate = self;
-  _appOpenAd.adapterAdFormat = @"GADMediationVungleAppOpenAd";
+  _appOpenAd.adapterAdFormat = NSStringFromClass(self.class);
   if (_adConfiguration.bidResponse) {
     // If bid response is present, then it is an RTB ad.
     VungleAdsExtras *extras = [[VungleAdsExtras alloc] init];


### PR DESCRIPTION
This commit will add

- logging adaptive banner size mismatch through VungleMediationLogger introduced in 7.7.1.
- setting adapterAdFormat property in basePublicAd introduced in 7.7.1.

[IOS-7949](https://vungle.atlassian.net/browse/IOS-7949)

[IOS-7949]: https://vungle.atlassian.net/browse/IOS-7949?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ