### PR TITLE
feat: add claude-native knowledge layer

### DIFF
--- a/.claude/conventions.yml
+++ b/.claude/conventions.yml
@@ -1,0 +1,39 @@
+conventions:
+  - id: adapter-structure
+    description: >
+      Each network adapter lives under adapters/{Network}/{Network}Adapter/.
+      Main adapter class: GADMediation{Network}Adapter. Router class manages
+      shared SDK lifecycle. Format-specific classes handle banner, interstitial,
+      and rewarded individually. Bidding has separate implementation classes.
+    applies_to: "adapters/**/*.{h,m}"
+
+  - id: naming-conventions
+    description: >
+      Main adapter: GADMediation{Network}Adapter. Router:
+      GADMediation{Network}Router. Format classes include the network name
+      and format (e.g., GAD{Network}InterstitialAd). Nullability annotations
+      required on all public headers. Objective-C naming conventions throughout.
+    applies_to: "adapters/**/*.{h,m}"
+
+  - id: ad-format-support
+    description: >
+      Adapters support Banner, Interstitial, and Rewarded Video at minimum.
+      Bidding variants have separate classes. Each format class handles its
+      own delegate callbacks. Consent handling is integrated where required
+      by the network SDK.
+    applies_to: "adapters/**/*.m"
+
+  - id: version-management
+    description: >
+      Each adapter has independent versioning. The adapter version encodes
+      the underlying SDK version. CHANGELOG.md per adapter tracks changes.
+      xcframework build scripts produce distributable binaries.
+    applies_to: "adapters/**/*"
+
+  - id: xcframework-build
+    description: >
+      Build scripts produce xcframework bundles for multi-architecture
+      distribution (device + simulator). Scripts handle lipo, xcodebuild,
+      and framework assembly. Output frameworks are used for binary
+      distribution alongside source.
+    applies_to: "**/*.sh"

--- a/.claude/knowledge/adrs/001-router-pattern.md
+++ b/.claude/knowledge/adrs/001-router-pattern.md
@@ -1,0 +1,25 @@
+# ADR-001: Centralized SDK Router Pattern
+
+## Status
+Accepted
+
+## Context
+Network SDKs on iOS typically use delegate-based callbacks. When multiple ad placements are active simultaneously, a single delegate must route callbacks to the correct ad request. The network SDK often supports only one delegate instance.
+
+## Decision
+Each network adapter uses a Router class (`GADMediation{Network}Router`) that:
+- Acts as the single delegate for the network SDK
+- Maintains a mapping of placement IDs to active ad request objects
+- Routes SDK callbacks to the correct format-specific handler
+- Manages shared SDK initialization state
+- Is implemented as a singleton or shared instance
+
+Format-specific classes (banner, interstitial, rewarded) register with the Router and receive their callbacks through it.
+
+## Consequences
+- Correctly handles concurrent ad requests across multiple placements
+- Single point of SDK lifecycle management
+- Format-specific classes are decoupled from direct SDK delegate registration
+- Router must be thread-safe for concurrent ad operations
+- Adds an indirection layer between the network SDK and format handlers
+- Router state must be cleaned up when ad objects are deallocated

--- a/.claude/knowledge/adrs/002-xcframework-distribution.md
+++ b/.claude/knowledge/adrs/002-xcframework-distribution.md
@@ -1,0 +1,24 @@
+# ADR-002: XCFramework Distribution
+
+## Status
+Accepted
+
+## Context
+iOS adapters need to support multiple architectures: arm64 for devices, x86_64/arm64 for simulators. Apple's transition to Apple Silicon means simulator builds also need arm64. Traditional fat/universal frameworks cannot contain two arm64 slices (device + simulator).
+
+## Decision
+Adapters are built as xcframeworks using build scripts that:
+1. Build the adapter for device (arm64) using `xcodebuild archive`
+2. Build for simulator (x86_64, arm64) using `xcodebuild archive`
+3. Combine using `xcodebuild -create-xcframework`
+4. Output the final `.xcframework` bundle
+
+Build scripts clean previous artifacts before rebuilding to ensure clean state.
+
+## Consequences
+- Full support for both Intel and Apple Silicon Macs (simulator)
+- xcframework is Apple's recommended multi-architecture format
+- Build scripts must be maintained alongside source code
+- Larger distribution size compared to source-only distribution
+- Enables binary distribution for partners who cannot compile from source
+- Compatible with both CocoaPods and manual integration

--- a/.claude/knowledge/adrs/003-bidding-adapter-classes.md
+++ b/.claude/knowledge/adrs/003-bidding-adapter-classes.md
@@ -1,0 +1,22 @@
+# ADR-003: Separate Bidding Implementation Classes
+
+## Status
+Accepted
+
+## Context
+Google Mobile Ads SDK supports both waterfall mediation and programmatic bidding (Open Bidding). These two paths have different initialization flows, ad request parameters, and callback handling. Combining both in a single class increases complexity.
+
+## Decision
+Bidding and waterfall implementations are separated into distinct classes:
+- **Waterfall classes**: Handle traditional mediation with server parameters and waterfall ordering
+- **Bidding classes**: Handle Open Bidding with bid tokens, signal collection, and auction-based ad loading
+
+The main adapter class (`GADMediationAdapter{Network}`) determines which path to use and delegates to the appropriate implementation class. Both paths share the Router for SDK lifecycle management.
+
+## Consequences
+- Clean separation of concerns between bidding and waterfall logic
+- Each class is simpler and easier to test independently
+- Shared infrastructure (Router, Utils) is reused across both paths
+- More files per adapter (bidding + waterfall variants per format)
+- Adding a new ad format requires classes for both paths
+- Publishers can use either or both monetization strategies

--- a/.claude/knowledge/computed/adapter-class-index.md
+++ b/.claude/knowledge/computed/adapter-class-index.md
@@ -1,0 +1,60 @@
+# Google Mobile Ads (GMA) — Vungle iOS Mediation Adapter Class Index
+
+## Adapter Entry Point
+
+| Class | Superclass | File |
+|-------|-----------|------|
+| `GADMediationAdapterVungle` | `NSObject <GADRTBAdapter>` | `GADMediationAdapterVungle.m` |
+
+**Initialization**: `setUpWithConfiguration:completionHandler:` → calls `[VungleAds initWithAppId:]`
+**Version**: `+adSDKVersion` returns Vungle SDK version, `+adapterVersion` returns adapter version
+
+## Format Classes
+
+| Format | Class | Google Protocol |
+|--------|-------|----------------|
+| Interstitial | `GADMAdapterVungleInterstitial` | `GADMediationInterstitialAd` |
+| Rewarded | `GADMAdapterVungleRewardedAd` | `GADMediationRewardedAd` |
+| Banner | `GADMAdapterVungleBanner` | `GADMediationBannerAd` |
+| Bidding Interstitial | `GADMAdapterVungleBiddingInterstitial` | `GADMediationInterstitialAd` |
+| Bidding Rewarded | `GADMAdapterVungleBiddingRewardedAd` | `GADMediationRewardedAd` |
+| Bidding Banner | `GADMAdapterVungleBiddingBanner` | `GADMediationBannerAd` |
+
+## Router Singleton
+
+```
+GADMAdapterVungleRouter.sharedInstance
+  ├─ initWithAppId: (one-time initialization)
+  ├─ requestInterstitialAdWithPlacementID:delegate:
+  ├─ requestRewardedAdWithPlacementID:delegate:
+  └─ requestBannerAdWithPlacementID:size:delegate:
+```
+
+The router manages ad lifecycle and delegates callbacks to the appropriate format adapter instance.
+
+## Callback Mapping (Vungle → Google GMA)
+
+| Vungle Callback | GMA Callback | Context |
+|----------------|-------------|---------|
+| `adDidLoad:` | `didLoadAd` (load callback) | Load success |
+| `adDidFailToLoad:withError:` | `didFailToPresentError:` | Load failure |
+| `adWillPresent:` | `willPresentFullScreenView` | About to show |
+| `adDidTrackImpression:` | `reportImpression` | Impression tracked |
+| `adDidClick:` | `reportClick` | Click |
+| `adDidClose:` | `didDismissFullScreenView` | Fullscreen closed |
+| `adDidRewardUser:` | `didEndVideo` + `didRewardUser` | Reward granted |
+
+## Bidding Support
+
+- Implements `GADRTBAdapter` protocol (extends `GADMediationAdapter`)
+- `collectSignalsForRequestParameters:completionHandler:` → `[VungleAds getBiddingToken]`
+- Separate bidding adapter classes handle RTB-specific load flow with bid payload
+
+## Key Patterns
+
+1. **Router singleton**: `GADMAdapterVungleRouter` centralizes ad lifecycle management, delegates to per-instance adapters
+2. **Waterfall vs Bidding split**: Separate classes for waterfall (`GADMAdapterVungle*`) and bidding (`GADMAdapterVungleBidding*`) flows
+3. **Error domain mapping**: Vungle errors mapped to `GADMAdapterVungleErrorDomain` with Google-standard codes
+4. **Banner size mapping**: Google `GADAdSize` → Vungle banner size via helper method
+5. **Server parameters**: App ID and placement ID from `GADMediationCredentials.settings` dictionary
+6. **Privacy**: GDPR/CCPA/COPPA forwarded via `VunglePrivacySettings` from mediation extras

--- a/.claude/knowledge/computed/churn-leaders.md
+++ b/.claude/knowledge/computed/churn-leaders.md
@@ -1,0 +1,16 @@
+# Churn Leaders
+# Auto-generated — do not edit manually
+
+## Files With Most Lines Changed (last 90 days)
+
+| Rank | File | Lines Added | Lines Removed | Net |
+|------|------|------------|--------------|-----|
+| - | `CLAUDE.md` | +45 | -0 | 45 |
+| - | `.claude/conventions.yml` | +39 | -0 | 39 |
+| - | `.claude/review-rules.yml` | +27 | -0 | 27 |
+| - | `.claude/knowledge/adrs/001-router-pattern.md` | +25 | -0 | 25 |
+| - | `.claude/knowledge/adrs/002-xcframework-distribution.md` | +24 | -0 | 24 |
+| - | `.claude/knowledge/adrs/003-bidding-adapter-classes.md` | +22 | -0 | 22 |
+
+---
+_Generated: 2026-03-24 | Period: 2025-12-24 to 2026-03-24 | Commits: 1 | Authors: 0_

--- a/.claude/knowledge/computed/co-change-clusters.md
+++ b/.claude/knowledge/computed/co-change-clusters.md
@@ -1,0 +1,8 @@
+# Co-Change Clusters
+# Auto-generated — do not edit manually
+
+## Files That Frequently Change Together (last 90 days)
+
+
+---
+_Generated: 2026-03-24 | Period: 2025-12-24 to 2026-03-24 | Commits: 1 | Authors: 0_

--- a/.claude/knowledge/computed/contributor-summary.md
+++ b/.claude/knowledge/computed/contributor-summary.md
@@ -1,0 +1,10 @@
+# Contributor Summary
+# Auto-generated — do not edit manually
+
+## Top Contributors (last 90 days)
+
+| Author | Commits | Files Touched |
+|--------|---------|--------------|
+
+---
+_Generated: 2026-03-24 | Period: 2025-12-24 to 2026-03-24 | Commits: 1 | Authors: 0_

--- a/.claude/knowledge/computed/git-intelligence.json
+++ b/.claude/knowledge/computed/git-intelligence.json
@@ -1,0 +1,24 @@
+{
+  "generated": "2026-03-23T00:00:00Z",
+  "period_days": 180,
+  "since": "2025-09-24",
+  "recent_activity": {
+    "total_commits": 1,
+    "unique_authors": 1,
+    "fix_bug_commits": 0,
+    "first_commit_date": "2026-03-20",
+    "last_commit_date": "2026-03-20",
+    "commits_per_month": {
+      "2026-03": 1
+    }
+  },
+  "top_authors": [
+    {"author": "Mian Leow", "commits": 1}
+  ],
+  "file_churn": [
+    {"file": "CLAUDE.md", "commits": 1},    {"file": ".claude/review-rules.yml", "commits": 1},    {"file": ".claude/knowledge/adrs/003-bidding-adapter-classes.md", "commits": 1},    {"file": ".claude/knowledge/adrs/002-xcframework-distribution.md", "commits": 1},    {"file": ".claude/knowledge/adrs/001-router-pattern.md", "commits": 1},    {"file": ".claude/conventions.yml", "commits": 1}
+  ],
+  "bug_hotspots": [
+
+  ]
+}

--- a/.claude/knowledge/computed/hotspot-map.md
+++ b/.claude/knowledge/computed/hotspot-map.md
@@ -1,0 +1,17 @@
+# Git Hotspot Map
+# Auto-generated — do not edit manually
+# Re-run: .claude/scripts/git-hotspots.sh
+
+## Most Frequently Changed Files (last 90 days)
+
+| Rank | File | Commits | Last Changed |
+|------|------|---------|-------------|
+| - | `CLAUDE.md` | 1 | 2026-03-20 |
+| - | `.claude/review-rules.yml` | 1 | 2026-03-20 |
+| - | `.claude/knowledge/adrs/003-bidding-adapter-classes.md` | 1 | 2026-03-20 |
+| - | `.claude/knowledge/adrs/002-xcframework-distribution.md` | 1 | 2026-03-20 |
+| - | `.claude/knowledge/adrs/001-router-pattern.md` | 1 | 2026-03-20 |
+| - | `.claude/conventions.yml` | 1 | 2026-03-20 |
+
+---
+_Generated: 2026-03-24 | Period: 2025-12-24 to 2026-03-24 | Commits: 1 | Authors: 0_

--- a/.claude/knowledge/computed/meta.yml
+++ b/.claude/knowledge/computed/meta.yml
@@ -1,0 +1,8 @@
+# Claude knowledge layer metadata
+generated: 2026-03-23T00:00:00Z
+source_commit: 38824177272ac651f34ec680f5a75879a9791b32
+stale_if_older_than: 7d
+artifacts:
+  git-intelligence.json: { bytes: 829, tokens: ~207 }
+total_bytes: 829
+total_tokens: ~207

--- a/.claude/review-rules.yml
+++ b/.claude/review-rules.yml
@@ -1,0 +1,27 @@
+review_rules:
+  - path: "adapters/**/*.{h,m}"
+    rules:
+      - Main adapter class must implement GADMediationAdapter protocol
+      - Router class must handle shared SDK state and delegate routing correctly
+      - All callbacks must dispatch to main queue via GCD
+      - Nullability annotations required on all public header declarations
+      - Early return pattern preferred over deep nesting
+      - Bidding and waterfall classes must be separate implementations
+
+  - path: "adapters/**/*Router*.{h,m}"
+    rules:
+      - Router must be a singleton or shared instance
+      - Must correctly route callbacks to the originating ad request
+      - Must handle concurrent ad requests for different placements
+      - SDK initialization state must be tracked and reused
+
+  - path: "**/*.sh"
+    rules:
+      - xcframework build scripts must handle both device and simulator architectures
+      - Scripts must clean build artifacts before rebuilding
+      - Output path must be clearly defined and consistent
+
+  - path: "adapters/**/CHANGELOG.md"
+    rules:
+      - Every version bump must have a corresponding CHANGELOG entry
+      - Entries should note SDK version updates, new format support, and bug fixes

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,45 @@
+# Google Ads Mobile iOS Mediation
+
+## Overview
+Google-maintained iOS mediation adapters for the Google Mobile Ads SDK. Contains 18 third-party network adapters enabling mediation through AdMob/Ad Manager.
+
+## Language
+- **Objective-C** (100% for adapters)
+
+## Build System
+- **Xcode projects** for adapter builds
+- **xcframework build scripts** for multi-architecture distribution
+- **CocoaPods** for example app dependencies
+
+## Architecture
+- Directory structure: `adapters/{Network}/{Network}Adapter/`
+- Main adapter class: `GADMediation{Network}Adapter`
+- Router pattern: Centralized SDK lifecycle management via shared Router class
+- Format-specific classes for banner, interstitial, rewarded
+- Bidding support via separate bidding adapter classes
+
+## Vungle Adapter
+- Main class: `GADMediationAdapterVungle`
+- Supporting: Banner, Interstitial, Rewarded format classes + Router + Utils
+- Bidding support with signal collection
+- Consent handling integration
+
+## Ad Formats
+- Banner
+- Interstitial
+- Rewarded Video
+- Bidding variants of each format
+
+## Code Standards
+- Early return pattern
+- GCD for threading (`dispatch_async`, `dispatch_get_main_queue`)
+- Nullability annotations (`nullable`, `nonnull`)
+
+## Example App
+- `MediationExample` app for manual testing
+
+## Key Conventions
+- Router class per adapter for shared SDK state
+- Separate classes for bidding vs. waterfall
+- Format-specific delegate/callback classes
+- Utils class for shared helper methods


### PR DESCRIPTION
## Summary
- Add `.claude/knowledge/` directory with repo-specific context for Claude Code
- Includes computed indices (git hotspots, churn leaders, co-change clusters), ADRs, and conventions where applicable
- Part of the **claude-native initiative** — structured context that makes Claude Code deeply understand this repo

## What this enables
- Claude Code understands this repo's architecture, hot paths, and conventions
- PR reviews automatically flag files with high fix frequency and known bug patterns
- Cross-repo impact analysis works across the full 48-repo codebase

## Details
- Central knowledge layer: [Vungle/claude-knowledge](https://github.com/Vungle/claude-knowledge/tree/claude-knowledge-layer)
- Gap analysis: [174/215 items closed (81%)](https://github.com/Vungle/claude-knowledge/blob/claude-knowledge-layer/docs/gap-analysis-2026-03-28.md)
- No runtime impact — these are context files only, read by Claude Code IDE

## Test plan
- [ ] Verify `.claude/knowledge/` files are accurate for this repo
- [ ] Open Claude Code in this repo and ask a domain-specific question
- [ ] Confirm no build/test impact (context files only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)