### PR TITLE
[IOS-8054] Log multiple App IDs case

### DIFF
--- a/adapters/LiftoffMonetize/LiftoffMonetizeAdapter/GADMAdapterVungleConstants.h
+++ b/adapters/LiftoffMonetize/LiftoffMonetizeAdapter/GADMAdapterVungleConstants.h
@@ -14,7 +14,7 @@
 
 #import <Foundation/Foundation.h>
 
-static NSString *const _Nonnull GADMAdapterVungleVersion = @"7.7.1.0";
+static NSString *const _Nonnull GADMAdapterVungleVersion = @"7.7.2.0";
 static NSString *const _Nonnull GADMAdapterVungleApplicationID = @"application_id";
 static NSString *const _Nonnull GADMAdapterVunglePlacementID = @"placementID";
 static NSString *const _Nonnull GADMAdapterVungleErrorDomain = @"com.google.mediation.vungle";

--- a/adapters/LiftoffMonetize/LiftoffMonetizeAdapter/GADMediationAdapterVungle.m
+++ b/adapters/LiftoffMonetize/LiftoffMonetizeAdapter/GADMediationAdapterVungle.m
@@ -65,10 +65,12 @@
 
   NSString *applicationID = [applicationIDs anyObject];
   if (applicationIDs.count > 1) {
-    NSLog(@"Found the following application IDs: %@. "
-          @"Please remove any application IDs you are not using from the AdMob UI.",
-          applicationIDs);
-    NSLog(@"Configuring Vungle SDK with the application ID %@.", applicationID);
+    NSString *logMessage = [NSString stringWithFormat:
+                            @"Multiple application ID entries found: %@. Using '%@' to initialize the Vungle SDK.",
+                            applicationIDs, applicationID];
+    NSLog(@"%@", logMessage);
+    NSLog(@"Please remove any application IDs you are not using from the AdMob UI.");
+    [VungleMediationLogger logErrorForAd:nil message:logMessage];
   }
 
   [GADMAdapterVungleRouter.sharedInstance initWithAppId:applicationID delegate:nil];


### PR DESCRIPTION
Use MediationLogger to log the case in which multiple app IDs are passed in.
[IOS-8054](https://vungle.atlassian.net/browse/IOS-8054)

[IOS-8054]: https://vungle.atlassian.net/browse/IOS-8054?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ