### PR TITLE
[IOS-8019] Adapter Logging Phase 2

### DIFF
--- a/adapters/LiftoffMonetize/LiftoffMonetizeAdapter/GADMAdapterVungleConstants.h
+++ b/adapters/LiftoffMonetize/LiftoffMonetizeAdapter/GADMAdapterVungleConstants.h
@@ -14,7 +14,7 @@
 
 #import <Foundation/Foundation.h>
 
-static NSString *const _Nonnull GADMAdapterVungleVersion = @"7.7.2.0";
+static NSString *const _Nonnull GADMAdapterVungleVersion = @"7.7.3.0";
 static NSString *const _Nonnull GADMAdapterVungleApplicationID = @"application_id";
 static NSString *const _Nonnull GADMAdapterVunglePlacementID = @"placementID";
 static NSString *const _Nonnull GADMAdapterVungleErrorDomain = @"com.google.mediation.vungle";

--- a/adapters/LiftoffMonetize/LiftoffMonetizeAdapter/GADMediationVungleAppOpenAd.m
+++ b/adapters/LiftoffMonetize/LiftoffMonetizeAdapter/GADMediationVungleAppOpenAd.m
@@ -130,14 +130,7 @@
 #pragma mark - GADMediationAppOpenAd Methods
 
 - (void)presentFromViewController:(UIViewController *)rootViewController {
-  if ([_appOpenAd canPlayAd]) {
     [_appOpenAd presentWith:rootViewController];
-  } else {
-    [_adEventDelegate
-        didFailToPresentWithError:GADMAdapterVungleErrorWithCodeAndDescription(
-                                      GADMAdapterVungleErrorCannotPlayAd,
-                                      @"Failed to show app open ad from Liftoff Monetize.")];
-  }
 }
 
 #pragma mark - VungleInterstitialDelegate


### PR DESCRIPTION
This commit will remove the `canPlayAd` check for AppOpen ad, and let SDK fails when ad is not ready to play properly.

[IOS-8019](https://vungle.atlassian.net/browse/IOS-8019)

[IOS-8019]: https://vungle.atlassian.net/browse/IOS-8019?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ