### PR TITLE
[IOS-8172] Deliver publisher_reporting data to publishers via VungleAdNetworkExtras handler

### DIFF
--- a/adapters/LiftoffMonetize/LiftoffMonetizeAdapter/Bidding/GADMediationVungleBanner.m
+++ b/adapters/LiftoffMonetize/LiftoffMonetizeAdapter/Bidding/GADMediationVungleBanner.m
@@ -39,6 +39,10 @@
 
   /// Liftoff Monetize bannerView ad instance.
   VungleBannerView *_bannerAdView;
+
+  /// Publisher's reporting-data handler, captured at request time so it always corresponds to
+  /// this ad request even if the extras object is reused across requests.
+  void (^_publisherReportDataHandler)(NSDictionary<NSString *, id> *_Nonnull);
 }
 
 @synthesize desiredPlacement;
@@ -60,6 +64,10 @@
 
     self.desiredPlacement =
         [GADMAdapterVungleUtils findPlacement:adConfiguration.credentials.settings];
+    if ([adConfiguration.extras isKindOfClass:[VungleAdNetworkExtras class]]) {
+      VungleAdNetworkExtras *extras = (VungleAdNetworkExtras *)adConfiguration.extras;
+      _publisherReportDataHandler = [extras.publisherReportDataHandler copy];
+    }
 
     __block atomic_flag adLoadHandlerCalled = ATOMIC_FLAG_INIT;
     __block GADMediationBannerLoadCompletionHandler origAdLoadHandler = [completionHandler copy];
@@ -109,6 +117,8 @@
 #pragma mark - VungleBannerViewDelegate
 
 - (void)bannerAdDidLoad:(VungleBannerView *)bannerView {
+  [GADMAdapterVungleUtils deliverPublisherReportData:bannerView.publisherReporting
+                                             handler:_publisherReportDataHandler];
   if (_adLoadCompletionHandler) {
     _delegate = _adLoadCompletionHandler(self, nil);
   }

--- a/adapters/LiftoffMonetize/LiftoffMonetizeAdapter/Bidding/GADMediationVungleInterstitial.m
+++ b/adapters/LiftoffMonetize/LiftoffMonetizeAdapter/Bidding/GADMediationVungleInterstitial.m
@@ -36,6 +36,10 @@
 
   /// Liftoff Monetize interstitial ad instance.
   VungleInterstitial *_interstitialAd;
+
+  /// Publisher's reporting-data handler, captured at request time so it always corresponds to
+  /// this ad request even if the extras object is reused across requests.
+  void (^_publisherReportDataHandler)(NSDictionary<NSString *, id> *_Nonnull);
 }
 
 @synthesize desiredPlacement;
@@ -51,6 +55,10 @@
     _adConfiguration = adConfiguration;
     self.desiredPlacement =
         [GADMAdapterVungleUtils findPlacement:adConfiguration.credentials.settings];
+    if ([adConfiguration.extras isKindOfClass:[VungleAdNetworkExtras class]]) {
+      VungleAdNetworkExtras *extras = (VungleAdNetworkExtras *)adConfiguration.extras;
+      _publisherReportDataHandler = [extras.publisherReportDataHandler copy];
+    }
 
     __block atomic_flag adLoadHandlerCalled = ATOMIC_FLAG_INIT;
     __block GADMediationInterstitialLoadCompletionHandler origAdLoadHandler =
@@ -104,6 +112,8 @@
 #pragma mark - VungleInterstitialDelegate
 
 - (void)interstitialAdDidLoad:(nonnull VungleInterstitial *)interstitial {
+  [GADMAdapterVungleUtils deliverPublisherReportData:interstitial.publisherReporting
+                                             handler:_publisherReportDataHandler];
   if (_adLoadCompletionHandler) {
     _delegate = _adLoadCompletionHandler(self, nil);
   }

--- a/adapters/LiftoffMonetize/LiftoffMonetizeAdapter/Bidding/GADMediationVungleNativeAd.m
+++ b/adapters/LiftoffMonetize/LiftoffMonetizeAdapter/Bidding/GADMediationVungleNativeAd.m
@@ -39,6 +39,10 @@
 
   /// The Liftoff Monetize container to display the media (image/video).
   MediaView *_mediaView;
+
+  /// Publisher's reporting-data handler, captured at request time so it always corresponds to
+  /// this ad request even if the extras object is reused across requests.
+  void (^_publisherReportDataHandler)(NSDictionary<NSString *, id> *_Nonnull);
 }
 
 @synthesize desiredPlacement;
@@ -58,6 +62,10 @@
   self = [super init];
   if (self) {
     _adConfiguration = adConfiguration;
+    if ([adConfiguration.extras isKindOfClass:[VungleAdNetworkExtras class]]) {
+      VungleAdNetworkExtras *extras = (VungleAdNetworkExtras *)adConfiguration.extras;
+      _publisherReportDataHandler = [extras.publisherReportDataHandler copy];
+    }
 
     // Store the ad config and completion handler for later use.
     __block atomic_flag adLoadHandlerCalled = ATOMIC_FLAG_INIT;
@@ -233,6 +241,8 @@
     return;
   }
 
+  [GADMAdapterVungleUtils deliverPublisherReportData:nativeAd.publisherReporting
+                                             handler:_publisherReportDataHandler];
   _mediaView = [[MediaView alloc] init];
   _delegate = _adLoadCompletionHandler(self, nil);
 }

--- a/adapters/LiftoffMonetize/LiftoffMonetizeAdapter/Bidding/GADMediationVungleRewardedAd.m
+++ b/adapters/LiftoffMonetize/LiftoffMonetizeAdapter/Bidding/GADMediationVungleRewardedAd.m
@@ -34,6 +34,10 @@
 
   /// Liftoff Monetize rewarded ad instance.
   VungleRewarded *_rewardedAd;
+
+  /// Publisher's reporting-data handler, captured at request time so it always corresponds to
+  /// this ad request even if the extras object is reused across requests.
+  void (^_publisherReportDataHandler)(NSDictionary<NSString *, id> *_Nonnull);
 }
 
 @synthesize desiredPlacement;
@@ -44,6 +48,10 @@
   self = [super init];
   if (self) {
     _adConfiguration = adConfiguration;
+    if ([adConfiguration.extras isKindOfClass:[VungleAdNetworkExtras class]]) {
+      VungleAdNetworkExtras *extras = (VungleAdNetworkExtras *)adConfiguration.extras;
+      _publisherReportDataHandler = [extras.publisherReportDataHandler copy];
+    }
 
     __block atomic_flag adLoadHandlerCalled = ATOMIC_FLAG_INIT;
     __block GADMediationRewardedLoadCompletionHandler origAdLoadHandler = [handler copy];
@@ -110,6 +118,8 @@
 #pragma mark - VungleRewardedDelegate
 
 - (void)rewardedAdDidLoad:(nonnull VungleRewarded *)rewarded {
+  [GADMAdapterVungleUtils deliverPublisherReportData:rewarded.publisherReporting
+                                             handler:_publisherReportDataHandler];
   if (_adLoadCompletionHandler) {
     _delegate = _adLoadCompletionHandler(self, nil);
   }

--- a/adapters/LiftoffMonetize/LiftoffMonetizeAdapter/GADMAdapterVungleRewardBasedVideoAd.m
+++ b/adapters/LiftoffMonetize/LiftoffMonetizeAdapter/GADMAdapterVungleRewardBasedVideoAd.m
@@ -34,6 +34,10 @@
 
   /// Liftoff Monitize rewarded ad instance.
   VungleRewarded *_rewardedAd;
+
+  /// Publisher's reporting-data handler, captured at request time so it always corresponds to
+  /// this ad request even if the extras object is reused across requests.
+  void (^_publisherReportDataHandler)(NSDictionary<NSString *, id> *_Nonnull);
 }
 
 @synthesize desiredPlacement;
@@ -50,6 +54,10 @@
   self = [super init];
   if (self) {
     _adConfiguration = adConfiguration;
+    if ([adConfiguration.extras isKindOfClass:[VungleAdNetworkExtras class]]) {
+      VungleAdNetworkExtras *extras = (VungleAdNetworkExtras *)adConfiguration.extras;
+      _publisherReportDataHandler = [extras.publisherReportDataHandler copy];
+    }
 
     __block atomic_flag adLoadHandlerCalled = ATOMIC_FLAG_INIT;
     __block GADMediationRewardedLoadCompletionHandler origAdLoadHandler = [handler copy];
@@ -113,6 +121,8 @@
 #pragma mark - VungleRewardedDelegate
 
 - (void)rewardedAdDidLoad:(nonnull VungleRewarded *)rewarded {
+  [GADMAdapterVungleUtils deliverPublisherReportData:rewarded.publisherReporting
+                                             handler:_publisherReportDataHandler];
   if (_adLoadCompletionHandler) {
     _delegate = _adLoadCompletionHandler(self, nil);
   }

--- a/adapters/LiftoffMonetize/LiftoffMonetizeAdapter/GADMAdapterVungleUtils.h
+++ b/adapters/LiftoffMonetize/LiftoffMonetizeAdapter/GADMAdapterVungleUtils.h
@@ -40,4 +40,10 @@ void GADMAdapterVungleMutableSetAddObject(NSMutableSet *_Nullable set, NSObject 
 /// Updates the Vungle COPPA status if needed.
 + (void)updateVungleCOPPAStatusIfNeeded;
 
+/// Invokes |handler| on the main thread with |reportData|, the loaded ad's publisher
+/// reporting data, delivered unmodified. No-op if |handler| or |reportData| is nil.
++ (void)deliverPublisherReportData:(nullable NSDictionary<NSString *, id> *)reportData
+                           handler:(void (^_Nullable)(
+                                       NSDictionary<NSString *, id> *_Nonnull))handler;
+
 @end

--- a/adapters/LiftoffMonetize/LiftoffMonetizeAdapter/GADMAdapterVungleUtils.m
+++ b/adapters/LiftoffMonetize/LiftoffMonetizeAdapter/GADMAdapterVungleUtils.m
@@ -85,6 +85,24 @@ VungleAdSize *_Nonnull GADMAdapterVungleConvertGADAdSizeToVungleAdSize(
   }
 }
 
++ (void)deliverPublisherReportData:(nullable NSDictionary<NSString *, id> *)reportData
+                           handler:(void (^_Nullable)(
+                                       NSDictionary<NSString *, id> *_Nonnull))handler {
+  if (!handler || !reportData) {
+    // Missing report data means the publisher is not enrolled / the field is absent from
+    // the ad response — expected, not an error.
+    return;
+  }
+  if (NSThread.isMainThread) {
+    handler(reportData);
+  } else {
+    // Defensive: the Vungle SDK fires its load callbacks on the main thread already.
+    dispatch_async(dispatch_get_main_queue(), ^{
+      handler(reportData);
+    });
+  }
+}
+
 #pragma mark - Safe Collection utility methods.
 
 void GADMAdapterVungleMutableSetAddObject(NSMutableSet *_Nullable set, NSObject *_Nonnull object) {

--- a/adapters/LiftoffMonetize/LiftoffMonetizeAdapter/GADMediationVungleAppOpenAd.m
+++ b/adapters/LiftoffMonetize/LiftoffMonetizeAdapter/GADMediationVungleAppOpenAd.m
@@ -35,6 +35,10 @@
   /// Liftoff Monetize app open ad instance. Note: Liftoff uses VungleInterstitial for displaying
   /// app open ads.
   VungleInterstitial *_appOpenAd;
+
+  /// Publisher's reporting-data handler, captured at request time so it always corresponds to
+  /// this ad request even if the extras object is reused across requests.
+  void (^_publisherReportDataHandler)(NSDictionary<NSString *, id> *_Nonnull);
 }
 
 @synthesize desiredPlacement;
@@ -50,6 +54,10 @@
     _adConfiguration = adConfiguration;
     _isLoadCompletionHandlerCalled = NO;
     _loadCompletionHandler = [loadCompletionHandler copy];
+    if ([adConfiguration.extras isKindOfClass:[VungleAdNetworkExtras class]]) {
+      VungleAdNetworkExtras *extras = (VungleAdNetworkExtras *)adConfiguration.extras;
+      _publisherReportDataHandler = [extras.publisherReportDataHandler copy];
+    }
   }
   return self;
 }
@@ -136,6 +144,8 @@
 #pragma mark - VungleInterstitialDelegate
 
 - (void)interstitialAdDidLoad:(nonnull VungleInterstitial *)appOpenAd {
+  [GADMAdapterVungleUtils deliverPublisherReportData:appOpenAd.publisherReporting
+                                             handler:_publisherReportDataHandler];
   [self callLoadCompletionHandlerIfNeededWithAd:self error:nil];
 }
 

--- a/adapters/LiftoffMonetize/Public/Headers/VungleAdNetworkExtras.h
+++ b/adapters/LiftoffMonetize/Public/Headers/VungleAdNetworkExtras.h
@@ -32,4 +32,17 @@
  */
 @property(nonatomic, assign) GADAdChoicesPosition nativeAdOptionPosition;
 
+/*!
+ * @brief Block called on the main thread when a Liftoff Monetize ad loads, just before the
+ * Google Mobile Ads SDK load-success callback, with the Liftoff publisher reporting data for
+ * that ad.
+ * @discussion Optional. The dictionary is delivered as received from the Liftoff ad server;
+ * the key set is agreed per publisher integration. The handler is not called when Liftoff
+ * does not fill the request, when another network wins the mediation auction, or when the ad
+ * response contains no reporting data. Capture self weakly inside the block to avoid retain
+ * cycles.
+ */
+@property(nonatomic, copy) void (^_Nullable publisherReportDataHandler)
+    (NSDictionary<NSString *, id> *_Nonnull reportData);
+
 @end


### PR DESCRIPTION
## Summary

Adds `publisherReportDataHandler` to `VungleAdNetworkExtras` so publishers can receive the Liftoff `publisher_reporting` map through GMA mediation — one mechanism, uniform across all ad formats (interstitial, rewarded, waterfall rewarded, banner, app open, native).

Jira: [IOS-8172](https://vungle.atlassian.net/browse/IOS-8172) (story: [IOS-8171](https://vungle.atlassian.net/browse/IOS-8171))

## How it works

- Publisher sets the handler block on `VungleAdNetworkExtras` and registers it on `GADRequest` as usual
- Each ad load class copies the block at init (per-request; immune to extras reuse) and invokes it from the Vungle `...DidLoad:` callback, just before GMA's load-success completion, on the main thread
- The dictionary is passed through **verbatim** — the adapter never inspects keys, so new server-side keys need no adapter change
- Never called on no-fill / lost auction / responses without `publisher_reporting` — silent no-op, no impact on ad load or playback

## Changes

- `VungleAdNetworkExtras.h` — new public `publisherReportDataHandler` property
- `GADMAdapterVungleUtils` — shared nil-safe, main-thread delivery helper
- Capture + deliver wiring in all 6 load classes

## Notes

- Requires the VungleAds SDK release containing `publisherReporting` (IOS-8075 / 7.7.5)
- Verified: adapter and test app build against the source SDK; E2E wiring in admob-adapter-testapp-ios logs the delivered map for interstitial

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[IOS-8172]: https://vungle.atlassian.net/browse/IOS-8172?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[IOS-8171]: https://vungle.atlassian.net/browse/IOS-8171?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ